### PR TITLE
Update product.tpl

### DIFF
--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -122,6 +122,15 @@
                   {block name='product_add_to_cart'}
                     {include file='catalog/_partials/product-add-to-cart.tpl'}
                   {/block}
+                  
+                  {block name='product_availability_date'}
+                    {if $product.availability_date && $product.availability != 'available' }
+                      <div class="product-availability-date">
+                        <label>{l s='Availability date:' d='Shop.Theme.Catalog'} </label>
+                        <span>{$product.availability_date}</span>
+                      </div>
+                    {/if}
+                  {/block}
 
                   {block name='product_additional_info'}
                     {include file='catalog/_partials/product-additional-info.tpl'}


### PR DESCRIPTION
Hi,
While developing a client's site, we noticed that the product availability date was displayed in the product details tab.
I propose to display it directly next to the product.
The date will be more easily visible for the customers.
Lucas,
Piment Bleu Agency (FR)

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | display availability date directly next to the product
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Possible impacts? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
