### PR TITLE
Fix: quickview width buggy on some products

### DIFF
--- a/_dev/css/components/quickview.scss
+++ b/_dev/css/components/quickview.scss
@@ -5,6 +5,7 @@
   }
 
   .modal-content {
+    width: 100%;
     min-height: 28.13rem;
     background: $gray-light;
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The modal wasn't taking the full width on some products, specially with low description length
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27991.
| How to test?      | Create a product with just a title, then click on quickview on FO, also take care of the issue informations
| Possible impacts? | Quickview FO

## How does it look?
![image](https://user-images.githubusercontent.com/14963751/159491035-d30b17fa-8b90-4ac7-85ab-d2f0cdbcdc2d.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
