### PR TITLE
Set default value for form field values that are null

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -25,7 +25,7 @@
 {if $field.type == 'hidden'}
 
   {block name='form_field_item_hidden'}
-    <input type="hidden" name="{$field.name}" value="{$field.value}">
+    <input type="hidden" name="{$field.name}" value="{$field.value|default}">
   {/block}
 
 {else}
@@ -101,7 +101,7 @@
       {elseif $field.type === 'date'}
 
         {block name='form_field_item_date'}
-          <input id="field-{$field.name}" name="{$field.name}" class="form-control" type="date" value="{$field.value}"{if isset($field.availableValues.placeholder)} placeholder="{$field.availableValues.placeholder}"{/if}>
+          <input id="field-{$field.name}" name="{$field.name}" class="form-control" type="date" value="{$field.value|default}"{if isset($field.availableValues.placeholder)} placeholder="{$field.availableValues.placeholder}"{/if}>
           {if isset($field.availableValues.comment)}
             <span class="form-control-comment">
               {$field.availableValues.comment}
@@ -115,7 +115,7 @@
           <div class="js-parent-focus">
             {html_select_date
             field_order=DMY
-            time={$field.value}
+            time={$field.value|default}
             field_array={$field.name}
             prefix=false
             reverse_years=true
@@ -169,7 +169,7 @@
             class="form-control"
             name="{$field.name}"
             type="{$field.type}"
-            value="{$field.value}"
+            value="{$field.value|default}"
             {if $field.autocomplete}autocomplete="{$field.autocomplete}"{/if}
             {if isset($field.availableValues.placeholder)}placeholder="{$field.availableValues.placeholder}"{/if}
             {if $field.maxLength}maxlength="{$field.maxLength}"{/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In PHP 8.1, `htmlspecialchars()` deprecates receiving `null` as its first argument, a string should be given. As smarty is using `htmlspecialchars()` by default when displaying a variable, we must ensure that the variable is not `null`. This PR uses the [default modifier](https://www.smarty.net/docsv2/en/language.modifier.default.tpl) that will return an empty string if the variable is `null`.<br><img width="403" alt="Capture d’écran 2022-03-29 à 18 20 44" src="https://user-images.githubusercontent.com/2168836/160660378-e2560f48-c60e-4222-88dc-89b915c92538.png">
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | This one is tricky to test as it requires php 8.1 but PrestaShop is not ready yet for php 8.1. Maybe checking that the login/registration forms are still working ok is enough.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
