### PR TITLE
Fix customization quantity display & clean up order return template 

### DIFF
--- a/templates/customer/_partials/order-detail-no-return.tpl
+++ b/templates/customer/_partials/order-detail-no-return.tpl
@@ -93,13 +93,7 @@
             {/if}
           </td>
           <td>
-            {if $product.customizations}
-              {foreach $product.customizations as $customization}
-                {$customization.quantity}
-              {/foreach}
-            {else}
-              {$product.quantity}
-            {/if}
+            {$product.quantity}
           </td>
           <td class="text-xs-right">{$product.price}</td>
           <td class="text-xs-right">{$product.total}</td>
@@ -150,13 +144,7 @@
                 {$product.price}
               </div>
               <div class="col-xs-4">
-                {if $product.customizations}
-                  {foreach $product.customizations as $customization}
-                    {$customization.quantity}
-                  {/foreach}
-                {else}
-                  {$product.quantity}
-                {/if}
+                {$product.quantity}
               </div>
               <div class="col-xs-4 text-xs-right">
                 {$product.total}

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -110,9 +110,6 @@
                       <option value="{$smarty.section.quantity.index}">{$smarty.section.quantity.index}</option>
                     {/section}
                   </select>
-                  {if $product.customizations}
-                    <input type="hidden" value="1" name="customization_qty_input[{$customization.id_customization}]" />
-                  {/if}
                 </div>
                 {/if}
             </td>
@@ -177,16 +174,9 @@
                       {$product.price}
                     </div>
                     <div class="col-xs-4">
-                      {if $product.customizations}
-                        {foreach $product.customizations as $customization}
-                          <div class="q">{l s='Quantity' d='Shop.Theme.Catalog'}: {$customization.quantity}</div>
-                          <div class="s" id="_mobile_return_qty_{$product.id_order_detail}_{$customization.id_customization}"></div>
-                        {/foreach}
-                      {else}
-                        <div class="q">{l s='Quantity' d='Shop.Theme.Catalog'}: {$product.quantity}</div>
-                        {if $product.quantity > $product.qty_returned}
-                          <div class="s" id="_mobile_return_qty_{$product.id_order_detail}"></div>
-                        {/if}
+                      <div class="q">{l s='Quantity' d='Shop.Theme.Catalog'}: {$product.quantity}</div>
+                      {if $product.quantity > $product.qty_returned}
+                        <div class="s" id="_mobile_return_qty_{$product.id_order_detail}"></div>
                       {/if}
                       {if $product.qty_returned > 0}
                         <div>{l s='Returned' d='Shop.Theme.Customeraccount'}: {$product.qty_returned}</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Contains fixes and refactorings related to this PR https://github.com/PrestaShop/PrestaShop/pull/12422
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create an order containing customizations, the order details in the customer account should display correct quantities

![image](https://user-images.githubusercontent.com/793712/162824490-f3664c6d-d33d-42e7-b41d-4f9f06736556.png)

The order return should work fine as well because the customization info is already included in the order details as pointed out in https://github.com/PrestaShop/PrestaShop/pull/12422/commits/5dc00a8e10b1c14a3d5b43b73d8164187406a714

| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
