### PR TITLE
Set default id_customization before escaping

### DIFF
--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -162,7 +162,7 @@
               data-link-action            = "delete-from-cart"
               data-id-product             = "{$product.id_product|escape:'javascript'}"
               data-id-product-attribute   = "{$product.id_product_attribute|escape:'javascript'}"
-              data-id-customization   	  = "{$product.id_customization|escape:'javascript'}"
+              data-id-customization       = "{$product.id_customization|default|escape:'javascript'}"
           >
             {if empty($product.is_gift)}
               <i class="material-icons float-xs-left">delete</i>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Smarty use `strtr()` to escape string with `javascript` escape type but since PHP 8.1, passing `null` as first argument of `strtr()` is deprecated. This PR aims to fix this by setting an empty string in case `id_customization` is null.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | This one is hard to test and I'm not sure it needs to be tested
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
