### PR TITLE
Fix product images size consistency

### DIFF
--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -28,7 +28,7 @@
       {if $product.default_image}
         <img
           class="js-qv-product-cover img-fluid"
-          src="{$product.default_image.bySize.medium_default.url}"
+          src="{$product.default_image.bySize.large_default.url}"
           {if !empty($product.default_image.legend)}
             alt="{$product.default_image.legend}"
             title="{$product.default_image.legend}"
@@ -36,8 +36,8 @@
             alt="{$product.name}"
           {/if}
           loading="lazy"
-          width="{$product.default_image.bySize.medium_default.width}"
-          height="{$product.default_image.bySize.medium_default.height}"
+          width="{$product.default_image.bySize.large_default.width}"
+          height="{$product.default_image.bySize.large_default.height}"
         >
         <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
           <i class="material-icons zoom-in">search</i>


### PR DESCRIPTION
Ensure php templates and javascript dynamic update functions define same image sizes.

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Patch of https://github.com/PrestaShop/PrestaShop/pull/28426/commits/2c1b5da25ba11d8993352e324e489be63ce808e8 1.7.8.x fix
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #26557
| How to test?      | cf. #26557
| Possible impacts? | Weird behavior for Product quick view.