### PR TITLE
Avoid malformed ld+json if logo_details is missing

### DIFF
--- a/templates/_partials/microdata/head-jsonld.tpl
+++ b/templates/_partials/microdata/head-jsonld.tpl
@@ -27,9 +27,9 @@
     "@context": "https://schema.org",
     "@type": "Organization",
     "name" : "{$shop.name}",
-    "url" : "{$urls.pages.index}",
+    "url" : "{$urls.pages.index}"
     {if $shop.logo_details}
-      "logo": {
+     ,"logo": {
         "@type": "ImageObject",
         "url":"{$shop.logo_details.src}"
       }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | If  $shop.logo_details is missing then a malformed json was outputted given a trailing comma
| Type?             | bug fix
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28709.
| BC breaks?        |  no
| Deprecations?     | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
