### PR TITLE
fix displaying email on order confirmation

### DIFF
--- a/templates/checkout/order-confirmation.tpl
+++ b/templates/checkout/order-confirmation.tpl
@@ -13,7 +13,7 @@
             {/block}
 
             <p>
-              {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $order_customer.email]}
+              {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $customer.email]}
               {if $order.details.invoice_url}
                 {* [1][/1] is for a HTML tag. *}
                 {l


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the customer email appearing on the checkout confirmation page
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Place an order and check the string 'An email has been sent to your mail address %s' is populated with the correct email address

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
