### PR TITLE
Fix content width of registration form

### DIFF
--- a/_dev/css/components/customer.scss
+++ b/_dev/css/components/customer.scss
@@ -108,7 +108,8 @@
 }
 
 /*** Login page ***/
-.page-authentication {
+.page-authentication,
+.page-registration {
   #content {
     @include customer-area-base-box();
     max-width: 640px;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changing the controller of registration did change the content width, we need to adjust it
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/27755.
| How to test?      | Should be tested with https://github.com/PrestaShop/PrestaShop/pull/27755 , It fixes the width of the registration form with the new controller
| Possible impacts? | FO registration form

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
