### PR TITLE
FO: Fix the display of labels in/out stock

### DIFF
--- a/_dev/css/components/products.scss
+++ b/_dev/css/components/products.scss
@@ -117,6 +117,10 @@
       line-height: inherit;
     }
   }
+
+  .product-add-to-cart {
+    word-wrap: break-word;
+  }
 }
 
 .product-quantity {
@@ -203,6 +207,7 @@
   .tax-shipping-delivery-label {
     font-size: 0.8125rem;
     color: $gray;
+    word-wrap: break-word;
 
     .delivery-information {
       padding: 0 0 0 2px;
@@ -600,7 +605,7 @@
 }
 
 #product-availability {
-  display: inline-block;
+  display: inline;
   margin-top: 0.625rem;
   font-weight: 700;
 
@@ -697,6 +702,7 @@
     font-weight: 700;
     color: $white;
     text-transform: uppercase;
+    word-break: break-word;
     pointer-events: auto;
     background: $brand-primary;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In BO > product page, when we set those fields with too long characters. In FO, the display of those labels are broken.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28366
| How to test?      | Check the steps to reproduce in the issue
| Possible impacts? | FO>Product page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
