### PR TITLE
Update theme version and require PS 8 minimum

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -2,9 +2,9 @@ name: classic
 display_name: Classic
 version: 2.0.0
 author:
-  name: "PrestaShop Team"
-  email: "pub@prestashop.com"
-  url: "https://www.prestashop.com"
+  name: "PrestaShop SA and Contributors"
+  email: "contact@prestashop.com"
+  url: "https://www.prestashop-project.org"
 
 meta:
   compatibility:

--- a/config/theme.yml
+++ b/config/theme.yml
@@ -1,6 +1,6 @@
 name: classic
 display_name: Classic
-version: 1.0.0
+version: 2.0.0
 author:
   name: "PrestaShop Team"
   email: "pub@prestashop.com"

--- a/config/theme.yml
+++ b/config/theme.yml
@@ -8,7 +8,7 @@ author:
 
 meta:
   compatibility:
-    from: 1.7.0.0
+    from: 8.0.0
     to: ~
 
   available_layouts:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Updated the theme version to 2 to distinguish it from the version running in 1.7. Added minimum compatibility to PS 8. I also updated the theme's author information.
| Type?             | new feature
| BC breaks?        | yes - compatibility updated
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28387
| How to test?      | You can't install the theme on PS < 8
| Possible impacts? | This should only impact the theme's installation

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
