### PR TITLE
Fix jQuery event shorthand is deprecated - focus, focusout, hover

### DIFF
--- a/_dev/js/components/form.js
+++ b/_dev/js/components/form.js
@@ -31,10 +31,10 @@ export default class Form {
   }
 
   parentFocus() {
-    $('.js-child-focus').focus(function () {
+    $('.js-child-focus').on('focus', function () {
       $(this).closest('.js-parent-focus').addClass('focus');
     });
-    $('.js-child-focus').focusout(function () {
+    $('.js-child-focus').on('focusout', function () {
       $(this).closest('.js-parent-focus').removeClass('focus');
     });
   }

--- a/_dev/js/components/top-menu.js
+++ b/_dev/js/components/top-menu.js
@@ -30,7 +30,7 @@ export default class TopMenu extends DropDown {
   init() {
     let elmtClass;
     const self = this;
-    this.el.find('li').hover((e) => {
+    this.el.find('li').on('mouseenter mouseleave', (e) => {
       if (this.el.parent().hasClass('mobile')) {
         return;
       }

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -142,7 +142,7 @@ $(document).ready(() => {
 
     $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
 
-    $quantityInput.focusout(() => {
+    $quantityInput.on('focusout', () => {
       if ($quantityInput.val() === '' || $quantityInput.val() < $quantityInput.attr('min')) {
         $quantityInput.val($quantityInput.attr('min'));
         $quantityInput.trigger('change');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix well-known deprecated warnings following https://github.com/jquery-validation/jquery-validation/pull/2243 and https://api.jquery.com/focus, https://api.jquery.com/focusout
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes {paste the issue here}.
| How to test?      | 1. In terminal run: <br>`cd themes/classic/_dev` <br> `npm run build` <br> 2. In FO: Clear Web browser cache <br> 3. In BO Configure/Advanced/Performance: Clear  cache then **Disable** Smart cache for JavaScript in CCC; <br> 4. Add some products to Cart, then open Cart page and look at Web browser console to see the warnings (from `theme.js`) still there or not
| Possible impacts? | Prestashop 1.7.8.5, FireFox browser

![ps178_jquery_focus_focusout_hover_event_shorthand_deprecated](https://user-images.githubusercontent.com/3759923/173328215-1b141982-1324-4cff-893f-f3edede9e195.png)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
