### PR TITLE
Fix social title tag vertical alignment

### DIFF
--- a/_dev/css/partials/_commons.scss
+++ b/_dev/css/partials/_commons.scss
@@ -389,7 +389,6 @@ form {
   display: inline-block;
   width: 18px;
   height: 18px;
-  margin-top: 0.1rem;
   margin-right: 0.5rem;
   vertical-align: middle;
   cursor: pointer;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This Pull Request fix the issue  #28627 The social title tag is not vertically aligned because we have margin-top: 0.1 which is not necessary.
| Type?             | bug fix 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes (https://github.com/PrestaShop/PrestaShop/issues/28627).
| How to test?      |  Steps below :)

**On creation account form in Sign in page**
Go to FO > Click on Sign in button
Click on "No account? Create one here" link
See Social Title, now the vertical alignment is correct.

**On creation account form in checkout**
Go to FO > Click on one product
Add it to Cart
Click on "Proceed to checkout" button on modal
On Shopping Cart page, click on "Proceed to checkout" button
On step "Personal information" >See Social Title, now the vertical alignment is correct.

**On customer account**
Go to FO > Click on Sign in button
Connect to your customer account
Go on "Personal information" tab
See Social Title, now the vertical alignment is correct.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
