### PR TITLE
Fix ps_facetedsearch - bad display after clearing a filter of no result

### DIFF
--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -185,10 +185,13 @@ $(document).ready(() => {
     );
 
     const renderedProducts = $(data.rendered_products);
-    const productSelectors = $(prestashop.themeSelectors.listing.product, renderedProducts);
+    const productSelectors = $(prestashop.themeSelectors.listing.product);
 
     if (productSelectors.length > 0) {
-      productSelectors.removeClass().addClass($(prestashop.themeSelectors.listing.product).first().attr('class'));
+      productSelectors.removeClass().addClass(productSelectors.first().attr('class'));
+    }
+    else {
+      productSelectors.removeClass().addClass(renderedProducts.first().attr('class'));
     }
 
     $(prestashop.themeSelectors.listing.list).replaceWith(renderedProducts);

--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -189,8 +189,7 @@ $(document).ready(() => {
 
     if (productSelectors.length > 0) {
       productSelectors.removeClass().addClass(productSelectors.first().attr('class'));
-    }
-    else {
+    } else {
       productSelectors.removeClass().addClass(renderedProducts.first().attr('class'));
     }
 


### PR DESCRIPTION
When using module ps_facetedsearch, if we apply a filter that returns no product, then apply another filter that returns some products, the product box alignment will be broken. All other filters with not empty result will be affected till we refresh the whole page.
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In this PR Files Changed: line 194 (196) makes `$(prestashop.themeSelectors.listing.product)` returns `Undefined` when we have a no product result (`list` with no `product`). Then line 191 will set `Undefined` class for all 'product' in the next filter and break the alignment. <br> My solution is separate `renderedProducts` and `productSelectors`, if `productSelectors` is empty by whatever reason, we can use `renderedProducts` instead. <br>`const productSelectors` is used locally in `function updateProductListDOM(data)` so its modification won't affect any other functions.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | PrestaShop/PrestaShop/issues/28966
| How to test?      | After PR, make sure you rebuild theme asset, clear web browser cache, then follow the above issue's steps.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
