### PR TITLE
restore `form_field` block

### DIFF
--- a/templates/customer/_partials/customer-form.tpl
+++ b/templates/customer/_partials/customer-form.tpl
@@ -31,13 +31,15 @@
   <div>
     {block "form_fields"}
       {foreach from=$formFields item="field"}
-        {if $field.type === "password"}
-          <div class="field-password-policy">
+        {block "form_field"}
+          {if $field.type === "password"}
+            <div class="field-password-policy">
+              {form_field field=$field}
+            </div>
+          {else}
             {form_field field=$field}
-          </div>
-        {else}
-          {form_field field=$field}
-        {/if}
+          {/if}
+        {/block}
       {/foreach}
       {$hook_create_account_form nofilter}
     {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The `form_field` Smarty block seems to have been removed by mistake in #21, which among other things breaks the display of the "Create an account" heading above the password field at guest checkout.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29612
| How to test?      | Test every password fields of registering, guest checkout forms, it should work as expected
| Possible impacts? | none

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
