### PR TITLE
Fix summary cart display on mobile

### DIFF
--- a/_dev/css/components/cart.scss
+++ b/_dev/css/components/cart.scss
@@ -28,7 +28,6 @@
   }
 
   &.cart-summary-totals {
-    padding: 0 1.25rem 0.825rem;
 
     .cart-summary-line {
       padding: 0.5rem 0.2rem 0;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Total line isn't well aligned in summary cart for mobile.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#28996](https://github.com/PrestaShop/PrestaShop/issues/28996)
| How to test?      | Cf. https://github.com/PrestaShop/PrestaShop/issues/28996
| Possible impacts? | Summary carts
