### PR TITLE
Move the number of items in stock before the 'Add to cart' button and before to the stock label 

### DIFF
--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -75,7 +75,14 @@
           {else}
             <i class="material-icons product-unavailable">&#xE14B;</i>
           {/if}
+          {if $product.show_quantities}
+            <span data-stock="{$product.quantity}" data-allow-oosp="{$product.allow_oosp}">{$product.quantity}</span>
+          {/if}
           {$product.availability_message}
+         {else}
+          {if $product.show_quantities}
+            <span data-stock="{$product.quantity}" data-allow-oosp="{$product.allow_oosp}">{$product.quantity}</span>  <label class="label">{l s='In stock' d='Shop.Theme.Catalog'}</label>
+          {/if}
         {/if}
       </span>
     {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This Pull Request creates the improvement requested in the issue PrestaShop/hummingbird#512
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/512
| How to test?      | Steps Below :)


With this improvement we move number of stock before Add to Cart button.
If the user does not display or does not indicate this label we show the number of stock first and before the label "In Stock", for example: 300 in stock as @Julievrz propose in the issue.
If the user show the Stock Label we show the number of stock with the user label.

**When user doesn't display stock label**
![image](https://user-images.githubusercontent.com/100702024/187650439-bed7a22e-542c-487d-98db-b08c83f6bce9.png)

**When user display stock label**
![image](https://user-images.githubusercontent.com/100702024/187650683-00a80585-a631-4622-aa45-d2e156cd20c3.png)

Important: We keep the stock number in the product details.

