### PR TITLE
Fix bad selector to fix checkbox issues on RMA

### DIFF
--- a/_dev/js/selectors.js
+++ b/_dev/js/selectors.js
@@ -68,7 +68,7 @@ prestashop.themeSelectors = {
     searchLink: '.js-search-link',
   },
   order: {
-    returnForm: '#order-return-form, .js-order-return-form',
+    returnForm: '#order-return-form.js-order-return-form',
   },
   arrowDown: '.arrow-down, .js-arrow-down',
   arrowUp: '.arrow-up, .js-arrow-up',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The current selector select too many elements in customer.js (form + checkbox) because of the comma. Without the comma, it select only the checkbox as expected
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [Prestashop/](https://github.com/PrestaShop/PrestaShop/issues/28963)
| How to test?      | Check issue https://github.com/PrestaShop/PrestaShop/issues/28963
| Possible impacts? | 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
