### PR TITLE
Replace quickview button by see product button on customizable product

### DIFF
--- a/_dev/css/components/featuredproducts.scss
+++ b/_dev/css/components/featuredproducts.scss
@@ -155,7 +155,8 @@ $product-description-height: 70px;
       display: none;
     }
 
-    .quick-view {
+    .quick-view,
+    .see-product {
       font-size: $base-font-size;
       color: $gray;
 

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -53,9 +53,15 @@
 
         <div class="highlighted-informations{if !$product.main_variants} no-variants{/if}">
           {block name='quick_view'}
-            <a class="quick-view js-quick-view" href="#" data-link-action="quickview">
-              <i class="material-icons search">&#xE8B6;</i> {l s='Quick view' d='Shop.Theme.Actions'}
-            </a>
+            {if $product.customization_required}
+              <a class="see-product" href="{$product.url}">
+                <i class="material-icons search">&#xE8B6;</i> {l s='See product' d='Shop.Theme.Actions'}
+              </a>
+            {else}
+              <a class="quick-view js-quick-view" href="#" data-link-action="quickview">
+                <i class="material-icons search">&#xE8B6;</i> {l s='Quick view' d='Shop.Theme.Actions'}
+              </a>
+            {/if}
           {/block}
 
           {block name='product_variants'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The quickview is useless on customized product because we need to customize it before adding it to cart
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29659.
| How to test?      | Go on a product list with a customizable product and see if the button is well replaced

![image](https://user-images.githubusercontent.com/14963751/190646660-d5eff7bf-eca2-43f0-8167-564c66bde73a.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
