### PR TITLE
Avoid convert special link characters

### DIFF
--- a/templates/catalog/_partials/product-details.tpl
+++ b/templates/catalog/_partials/product-details.tpl
@@ -1,6 +1,6 @@
 <div class="js-product-details tab-pane fade{if !$product.description} in active{/if}"
      id="product-details"
-     data-product="{$product.embedded_attributes|json_encode}"
+     data-product="{json_encode($product.embedded_attributes, JSON_UNESCAPED_UNICODE)}"
      role="tabpanel"
   >
   {block name='product_reference'}


### PR DESCRIPTION
In some languages, such as Persian and Arabic, the "json_encode" function converts links with special characters into unintelligible characters. Google identifies these links incompletely and registers as a 404 error for them in Google search console


| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I just add one argument to json_encode function
| Type?             | bug fix / SEO critical
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | 1. Upload an image with Arabic or Persian name for a product<br>2. Goto above product page on FO<br>3. Inspect page and see image link in Js variables (in the script tag)
| Possible impacts? | No. after some time, you can see them on Google search console as a 404 pages (eg: "http://domain.com/1012-large_default")

