### PR TITLE
Bad display of Customer data privacy message when the text contains a link

### DIFF
--- a/_dev/css/partials/_commons.scss
+++ b/_dev/css/partials/_commons.scss
@@ -420,6 +420,7 @@ form {
 
 .custom-checkbox {
   position: relative;
+  word-break: break-word;
 
   input[type="checkbox"] {
     position: absolute;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When we add a link in the text of data privacy the text stands out from the div. If we add to the class .custom-checkbox the property word-break: break-word; we prevent this.
| Type?             |  improvement
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27155
| How to test?      | Go to BO> Modules> Module manager > Configure the module Customer data privacy block<br/>add a link in the message and save<br/>Go to Front office and open the account creation page

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
