### PR TITLE
Fix too long customization value on preview

### DIFF
--- a/_dev/css/components/customization-modal.scss
+++ b/_dev/css/components/customization-modal.scss
@@ -16,6 +16,10 @@
           text-align: right;
         }
 
+        .value {
+          word-wrap: break-word;
+        }
+
         &:last-child {
           padding-bottom: 0;
           border-bottom: 0;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There was a bug in case the product customization text was too long without any spaces
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29866.
| How to test?      | See issue
| Possible impacts? | Product customization modal value

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
