### PR TITLE
Fix image size when zooming on tablet

### DIFF
--- a/_dev/css/components/products.scss
+++ b/_dev/css/components/products.scss
@@ -344,7 +344,7 @@
       }
 
       .image-caption {
-        width: 800px;
+        width: 100%;
         padding: 0.625rem 1.25rem;
         background: $white;
         border-top: $gray-light 1px solid;
@@ -892,10 +892,6 @@
   #product-modal .modal-content .modal-body {
     flex-direction: column;
     margin-left: 0;
-
-    img.product-cover-modal {
-      width: 100%;
-    }
 
     .arrows {
       display: none;

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -30,7 +30,7 @@
         <figure>
           {if $product.default_image}
             <img
-              class="js-modal-product-cover product-cover-modal"
+              class="js-modal-product-cover product-cover-modal img-fluid"
               width="{$product.default_image.bySize.large_default.width}"
               src="{$product.default_image.bySize.large_default.url}"
               {if !empty($product.default_image.legend)}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Zoom product image had a wrong size on tablet, using img-fluid fixes it
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29865.
| How to test?      | See issue
| Possible impacts? | Product zoom image 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
