### PR TITLE
Show best sellers link if related option is enabled

### DIFF
--- a/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
+++ b/modules/ps_bestsellers/views/templates/hook/ps_bestsellers.tpl
@@ -27,7 +27,9 @@
     {l s='Best Sellers' d='Shop.Theme.Catalog'}
   </h2>
   {include file="catalog/_partials/productlist.tpl" products=$products productClass="col-xs-12 col-sm-6 col-lg-4 col-xl-3"}
-  <a class="all-product-link float-xs-left float-md-right h4" href="{$allBestSellers}">
-    {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
-  </a>
+  {if $displayBestSellers|default:true}
+    <a class="all-product-link float-xs-left float-md-right h4" href="{$allBestSellers}">
+      {l s='All best sellers' d='Shop.Theme.Catalog'}<i class="material-icons">&#xE315;</i>
+    </a>
+  {/if}
 </section>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Related to https://github.com/PrestaShop/ps_bestsellers/pull/23.
| Type?             | improvement 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | As this, the link will be shown every time. Once the related pull is merged/used, the variable will be set wuth the right value (true or false) and link will be not shown if not needed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
