### PR TITLE
Handling asynchronous prestashop.checkPasswordScore

### DIFF
--- a/_dev/js/components/usePasswordPolicy.js
+++ b/_dev/js/components/usePasswordPolicy.js
@@ -63,7 +63,7 @@ const getPasswordStrengthFeedback = (
   }
 };
 
-const watchPassword = (
+const watchPassword = async (
   elementInput,
   feedbackContainer,
   hints,
@@ -71,7 +71,7 @@ const watchPassword = (
   const {prestashop} = window;
   const passwordValue = elementInput.value;
   const elementIcon = feedbackContainer.querySelector(PasswordPolicyMap.requirementScoreIcon);
-  const result = prestashop.checkPasswordScore(passwordValue);
+  const result = await prestashop.checkPasswordScore(passwordValue);
   const feedback = getPasswordStrengthFeedback(result.score);
   const passwordLength = passwordValue.length;
   const popoverContent = [];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changes `usePasswordPolicy.js` to handle changes made in https://github.com/PrestaShop/PrestaShop/pull/30104.  `prestashop.checkPasswordScore` right now is returning promise instead of password score.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#30088](https://github.com/PrestaShop/PrestaShop/issues/30088)
| How to test?      | Follow instruction wrote here https://github.com/PrestaShop/PrestaShop/pull/30104. 
| Possible impacts? | Password policy feature only. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
