### PR TITLE
Fix:30071 - Button of file field in customization product has a smaller height rather than its field

### DIFF
--- a/_dev/css/components/products.scss
+++ b/_dev/css/components/products.scss
@@ -802,6 +802,7 @@
       top: 0;
       right: 0;
       z-index: 0;
+      height: inherit;
     }
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix for issue https://github.com/PrestaShop/PrestaShop/issues/30071
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30071.
| How to test?      | Follow Issue reproduce steps.
| Possible impacts? | NA.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
