### PR TITLE
Fix position of newsletter block in footer

### DIFF
--- a/_dev/css/components/footer.scss
+++ b/_dev/css/components/footer.scss
@@ -2,6 +2,12 @@
   padding-top: 2.5rem;
 }
 
+#blockEmailSubscription_displayFooterBefore {
+  float: inherit;
+  width: 100%;
+  margin: auto;
+}
+
 .block-contact {
   font-size: 0.875rem;
   color: $gray;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix position of newsletter block in footer
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29018
| How to test?      | Check if the block is centered in footer

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Because of this PR https://github.com/PrestaShop/classic-theme/pull/44 was closed, I reopen a new one.
@NeOMakinG you told put `margin: auto` is not a good choice because we don't want to apply it on each hook, but the selector is `#blockEmailSubscription_displayFooterBefore`

In P8 the `.block_newsletter` is override by `.col-x` classes, so I just add some properties from `.block_newsletter` to `#blockEmailSubscription_displayFooterBefore` to make it centered.
