### PR TITLE
Fix: changing the country creates a new address

### DIFF
--- a/templates/checkout/_partials/address-form.tpl
+++ b/templates/checkout/_partials/address-form.tpl
@@ -13,7 +13,7 @@
       method="POST"
       action="{url entity='order' params=['id_address' => $id_address]}"
       data-id-address="{$id_address}"
-      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm']}"
+      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm', 'id_address' => $id_address]}"
     >
 {/block}
 

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -30,7 +30,7 @@
       method="POST"
       data-id-address="{$id_address}"
       action="{url entity='order' params=['id_address' => $id_address]}"
-      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm']}"
+      data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm', 'id_address' => $id_address]}"
     >
 
       {if $use_same_address}

--- a/templates/customer/_partials/address-form.tpl
+++ b/templates/customer/_partials/address-form.tpl
@@ -31,7 +31,7 @@
       method="POST"
       action="{url entity='address' params=['id_address' => $id_address]}"
       data-id-address="{$id_address}"
-      data-refresh-url="{url entity='address' params=['ajax' => 1, 'action' => 'addressForm']}"
+      data-refresh-url="{url entity='address' params=['ajax' => 1, 'action' => 'addressForm', 'id_address' => $id_address]}"
     >
     {/block}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When changing the country in the form, an ajax call is made, and it needs to include the `$id_address`.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#30375](https://github.com/PrestaShop/PrestaShop/issues/30375)
| How to test?      | Follow the steps to reproduce in #30375. Notice that the form action URL still contains the address id after changing the country.
| Possible impacts? | This should not have any other impact than the one described.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
