### PR TITLE
check if additional_description exists

### DIFF
--- a/templates/catalog/_partials/category-footer.tpl
+++ b/templates/catalog/_partials/category-footer.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <div id="js-product-list-footer">
-    {if isset($category) && $category.additional_description && $listing.pagination.items_shown_from == 1}
+    {if isset($category) && isset($category.additional_description) && $listing.pagination.items_shown_from == 1}
         <div class="card">
             <div class="card-block category-additional-description">
                 {$category.additional_description nofilter}

--- a/templates/catalog/_partials/category-footer.tpl
+++ b/templates/catalog/_partials/category-footer.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <div id="js-product-list-footer">
-    {if isset($category) && isset($category.additional_description) && $listing.pagination.items_shown_from == 1}
+    {if isset($category) && !empty($category.additional_description) && $listing.pagination.items_shown_from == 1}
         <div class="card">
             <div class="card-block category-additional-description">
                 {$category.additional_description nofilter}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | `category.additional_description` is only available since PrestaShop/PrestaShop/pull/27292 (for PS 8.0.0), so PrestaShop/classic-theme/pull/18 need this tweak to make the theme compatible with PS 1.7.8.x
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop/issues/30595.
| How to test?      | Please check the fixed ticket.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
