### PR TITLE
Fix: Adds rule to avoid overflowing logo in maintenance mode

### DIFF
--- a/_dev/css/error.scss
+++ b/_dev/css/error.scss
@@ -12,6 +12,10 @@
   .logo {
     margin: 0 0 31px;
     text-align: center;
+
+    img {
+      max-width: 100%;
+    }
   }
 
   h1 {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In maintenance mode, big logo will overflow their container because the image doesn't have a maximum width.
| Type?             | bug fix 
| Fixed ticket? | Fixes [#30625](https://github.com/PrestaShop/PrestaShop/issues/30625)
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Upload a wide logo, then activate the maintenance mode. Go to the store and see if the logo is overflowing it's container or not.
| Possible impacts? | I don't see any.


Before:
![image](https://user-images.githubusercontent.com/25964813/208712486-c2374912-d863-4402-b84f-547b7f03971b.png)

After:
![image](https://user-images.githubusercontent.com/25964813/208712561-97bae7f1-ffda-4026-9052-9b41625db69e.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
