### PR TITLE
Add block for checkout footer copyright_link

### DIFF
--- a/templates/checkout/_partials/footer.tpl
+++ b/templates/checkout/_partials/footer.tpl
@@ -37,5 +37,7 @@
   {if $tos_cms != false}
     <span class="d-block js-terms">{$tos_cms nofilter}</span>
   {/if}
-  {l s='%copyright% %year% - Ecommerce software by %prestashop%' sprintf=['%prestashop%' => 'PrestaShop™', '%year%' => 'Y'|date, '%copyright%' => '©'] d='Shop.Theme.Global'}
+  {block name='copyright_link'}
+    {l s='%copyright% %year% - Ecommerce software by %prestashop%' sprintf=['%prestashop%' => 'PrestaShop™', '%year%' => 'Y'|date, '%copyright%' => '©'] d='Shop.Theme.Global'}
+  {/block}
 </div>


### PR DESCRIPTION
Put the checkout copyright link into a block for easier child theme workflow.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Putting the copyright link on the checkout templates footer into a block to enable easier child theme override (matching the main store template footer)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| How to test?      | Install theme, rebuild from templates, ensure checkout footer is not broken. Extra testing if desired: verify using the block in a child theme works.
| Possible impacts? | Should only impact the footer on 'checkout' pages

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
