### PR TITLE
Fix hacked column layout, fix responsivity of sorting

### DIFF
--- a/_dev/css/components/categories.scss
+++ b/_dev/css/components/categories.scss
@@ -448,7 +448,6 @@
 @include media-breakpoint-down(sm) {
   #category {
     #left-column {
-      width: 100%;
 
       #search_filters_wrapper {
         margin-right: -30px;
@@ -542,10 +541,6 @@
       }
     }
 
-    #content-wrapper {
-      width: 100%;
-    }
-
     #search_filter_toggler {
       width: 100%;
     }
@@ -567,12 +562,6 @@
     .showing {
       padding-top: 1rem;
     }
-  }
-
-  #prices-drop #content-wrapper,
-  #new-products #content-wrapper,
-  #best-sales #content-wrapper {
-    width: 100%;
   }
 }
 
@@ -613,7 +602,6 @@
     box-shadow: none;
   }
 }
-
 
 @include media-breakpoint-down(md) {
   #products {

--- a/templates/catalog/_partials/products-top.tpl
+++ b/templates/catalog/_partials/products-top.tpl
@@ -23,22 +23,20 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <div id="js-product-list-top" class="row products-selection">
-  <div class="col-md-6 hidden-sm-down total-products">
+  <div class="col-lg-5 hidden-sm-down total-products">
     {if $listing.pagination.total_items > 1}
       <p>{l s='There are %product_count% products.' d='Shop.Theme.Catalog' sprintf=['%product_count%' => $listing.pagination.total_items]}</p>
     {elseif $listing.pagination.total_items > 0}
       <p>{l s='There is 1 product.' d='Shop.Theme.Catalog'}</p>
     {/if}
   </div>
-  <div class="col-md-6">
+  <div class="col-lg-7">
     <div class="row sort-by-row">
-
       {block name='sort_by'}
         {include file='catalog/_partials/sort-orders.tpl' sort_orders=$listing.sort_orders}
       {/block}
-
       {if !empty($listing.rendered_facets)}
-        <div class="col-sm-3 col-xs-4 hidden-md-up filter-button">
+        <div class="col-xs-4 col-sm-3 hidden-md-up filter-button">
           <button id="search_filter_toggler" class="btn btn-secondary js-search-toggler">
             {l s='Filter' d='Shop.Theme.Actions'}
           </button>

--- a/templates/catalog/_partials/sort-orders.tpl
+++ b/templates/catalog/_partials/sort-orders.tpl
@@ -23,8 +23,8 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-<span class="col-sm-3 col-md-3 hidden-sm-down sort-by">{l s='Sort by:' d='Shop.Theme.Global'}</span>
-<div class="{if !empty($listing.rendered_facets)}col-sm-9 col-xs-8{else}col-sm-12 col-xs-12{/if} col-md-9 products-sort-order dropdown">
+<span class="col-sm-3 col-md-5 hidden-sm-down sort-by">{l s='Sort by:' d='Shop.Theme.Global'}</span>
+<div class="{if !empty($listing.rendered_facets)}col-xs-8 col-sm-7{else}col-xs-12 col-sm-12{/if} col-md-9 products-sort-order dropdown">
   <button
     class="btn-unstyle select-title"
     rel="nofollow"

--- a/templates/layouts/layout-both-columns.tpl
+++ b/templates/layouts/layout-both-columns.tpl
@@ -64,7 +64,7 @@
 
           <div class="row">
             {block name="left_column"}
-              <div id="left-column" class="col-xs-12 col-sm-4 col-md-3">
+              <div id="left-column" class="col-xs-12 col-md-4 col-lg-3">
                 {if $page.page_name == 'product'}
                   {hook h='displayLeftColumnProduct' product=$product category=$category}
                 {else}
@@ -74,7 +74,7 @@
             {/block}
 
             {block name="content_wrapper"}
-              <div id="content-wrapper" class="js-content-wrapper left-column right-column col-sm-4 col-md-6">
+              <div id="content-wrapper" class="js-content-wrapper left-column right-column col-md-4 col-lg-3">
                 {hook h="displayContentWrapperTop"}
                 {block name="content"}
                   <p>Hello world! This is HTML5 Boilerplate.</p>
@@ -84,7 +84,7 @@
             {/block}
 
             {block name="right_column"}
-              <div id="right-column" class="col-xs-12 col-sm-4 col-md-3">
+              <div id="right-column" class="col-xs-12 col-md-4 col-lg-3">
                 {if $page.page_name == 'product'}
                   {hook h='displayRightColumnProduct'}
                 {else}

--- a/templates/layouts/layout-left-column.tpl
+++ b/templates/layouts/layout-left-column.tpl
@@ -27,7 +27,7 @@
 {block name='right_column'}{/block}
 
 {block name='content_wrapper'}
-  <div id="content-wrapper" class="js-content-wrapper left-column col-xs-12 col-sm-8 col-md-9">
+  <div id="content-wrapper" class="js-content-wrapper left-column col-xs-12 col-md-8 col-lg-9">
     {hook h="displayContentWrapperTop"}
     {block name='content'}
       <p>Hello world! This is HTML5 Boilerplate.</p>

--- a/templates/layouts/layout-right-column.tpl
+++ b/templates/layouts/layout-right-column.tpl
@@ -27,7 +27,7 @@
 {block name='left_column'}{/block}
 
 {block name='content_wrapper'}
-  <div id="content-wrapper" class="js-content-wrapper right-column col-xs-12 col-sm-8 col-md-9">
+  <div id="content-wrapper" class="js-content-wrapper right-column col-xs-12 col-md-8 col-lg-9">
     {hook h="displayContentWrapperTop"}
     {block name='content'}
       <p>Hello world! This is HTML5 Boilerplate.</p>


### PR DESCRIPTION
**This should go to 2.0.x, 2.1.x and develop.**

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fixes broken column layout, if you enabled left column on pages, where it wasn't enabled by default. Also fixes responsivity of product list top section - sorting, product count.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | Play around in responsive mode and see that everything behaves correctly.

### How to test
- _Disclaimer - It does not fix broken column layout on some pages, this will be fixed in another PR. Hummingbird has the same issue._

[pr_757.webm](https://user-images.githubusercontent.com/23308427/216626595-747cda80-45f6-4121-82b7-2fc6df0f141c.webm)

- I would like @hibatallahAouadni to do the QA because she found out this issue. 
- To test best, get 8.1.x branch, install faceted search develop, enable filtering on all pages, enable left column for all pages in BO > Themes > Choose layouts.
- Then play around with responsive mode on category, manufacturer, search page and others and see that left column now displays correctly on all pages.