### PR TITLE
Implement picture tags

### DIFF
--- a/_dev/css/components/products.scss
+++ b/_dev/css/components/products.scss
@@ -556,7 +556,7 @@
   > li.thumb-container {
     display: inline;
 
-    > .thumb {
+    .thumb {
       margin-bottom: $small-space;
       cursor: pointer;
 

--- a/_dev/css/components/quickview.scss
+++ b/_dev/css/components/quickview.scss
@@ -37,7 +37,7 @@
     display: flex;
     min-height: 21.88rem;
 
-    .product-images li.thumb-container > .thumb {
+    .product-images > li.thumb-container .thumb {
       width: 100%;
       max-width: 4.938rem;
       height: auto;

--- a/_dev/css/components/quickview.scss
+++ b/_dev/css/components/quickview.scss
@@ -37,7 +37,7 @@
     display: flex;
     min-height: 21.88rem;
 
-    .product-images > li.thumb-container > .thumb {
+    .product-images li.thumb-container > .thumb {
       width: 100%;
       max-width: 4.938rem;
       height: auto;

--- a/_dev/js/components/product-select.js
+++ b/_dev/js/components/product-select.js
@@ -25,6 +25,7 @@
 import $ from 'jquery';
 // eslint-disable-next-line
 import 'velocity-animate';
+import updateSources from 'update-sources';
 
 export default class ProductSelect {
   init() {
@@ -46,18 +47,10 @@ export default class ProductSelect {
         $(prestashop.themeSelectors.product.modalProductCover).attr('alt', $(event.target).attr('alt'));
 
         // Get data from thumbnail and update cover sources
-        const sources = $(event.target).data('image-large-sources');
-        const productCoverWebp = $(prestashop.themeSelectors.product.modalProductCover)
-          .siblings('source[type="image/webp"]');
-        const productCoverAvif = $(prestashop.themeSelectors.product.modalProductCover)
-          .siblings('source[type="image/avif"]');
-
-        if (sources !== undefined && sources.webp !== undefined && productCoverWebp.length) {
-          productCoverWebp.attr('srcset', sources.webp);
-        }
-        if (sources !== undefined && sources.avif !== undefined && productCoverAvif.length) {
-          productCoverAvif.attr('srcset', sources.avif);
-        }
+        updateSources(
+          $(prestashop.themeSelectors.product.modalProductCover), 
+          $(event.target).data('image-large-sources')
+        );
       })
       .on('click', 'aside#thumbnails', (event) => {
         if (event.target.id === 'thumbnails') {

--- a/_dev/js/components/product-select.js
+++ b/_dev/js/components/product-select.js
@@ -34,15 +34,27 @@ export default class ProductSelect {
 
     $('body')
       .on('click', '.js-modal-thumb', (event) => {
+        // Swap active classes on thumbnail
         if ($('.js-modal-thumb').hasClass('selected')) {
           $('.js-modal-thumb').removeClass('selected');
         }
         $(event.currentTarget).addClass('selected');
 
-        // Change source, title and alt of the displayed image
+        // Get data from thumbnail and update cover src, alt and title
         $(prestashop.themeSelectors.product.modalProductCover).attr('src', $(event.target).data('image-large-src'));
         $(prestashop.themeSelectors.product.modalProductCover).attr('title', $(event.target).attr('title'));
         $(prestashop.themeSelectors.product.modalProductCover).attr('alt', $(event.target).attr('alt'));
+
+        // Get data from thumbnail and update cover sources
+        const sources = $(event.target).data('image-large-sources');
+        const productCoverWebp = $(prestashop.themeSelectors.product.modalProductCover).siblings('source[type="image/webp"]');
+        const productCoverAvif = $(prestashop.themeSelectors.product.modalProductCover).siblings('source[type="image/avif"]');
+        if (sources !== undefined && sources.webp !== undefined && productCoverWebp.length) {
+          productCoverWebp.attr('srcset', sources.webp);
+        }
+        if (sources !== undefined && sources.avif !== undefined && productCoverAvif.length) {
+          productCoverAvif.attr('srcset', sources.avif);
+        }
       })
       .on('click', 'aside#thumbnails', (event) => {
         if (event.target.id === 'thumbnails') {

--- a/_dev/js/components/product-select.js
+++ b/_dev/js/components/product-select.js
@@ -47,8 +47,11 @@ export default class ProductSelect {
 
         // Get data from thumbnail and update cover sources
         const sources = $(event.target).data('image-large-sources');
-        const productCoverWebp = $(prestashop.themeSelectors.product.modalProductCover).siblings('source[type="image/webp"]');
-        const productCoverAvif = $(prestashop.themeSelectors.product.modalProductCover).siblings('source[type="image/avif"]');
+        const productCoverWebp = $(prestashop.themeSelectors.product.modalProductCover)
+          .siblings('source[type="image/webp"]');
+        const productCoverAvif = $(prestashop.themeSelectors.product.modalProductCover)
+          .siblings('source[type="image/avif"]');
+
         if (sources !== undefined && sources.webp !== undefined && productCoverWebp.length) {
           productCoverWebp.attr('srcset', sources.webp);
         }

--- a/_dev/js/components/product-select.js
+++ b/_dev/js/components/product-select.js
@@ -38,9 +38,11 @@ export default class ProductSelect {
           $('.js-modal-thumb').removeClass('selected');
         }
         $(event.currentTarget).addClass('selected');
-        $('.js-modal-product-cover').attr('src', $(event.target).data('image-large-src'));
-        $('.js-modal-product-cover').attr('title', $(event.target).attr('title'));
-        $('.js-modal-product-cover').attr('alt', $(event.target).attr('alt'));
+
+        // Change source, title and alt of the displayed image
+        $(prestashop.themeSelectors.product.modalProductCover).attr('src', $(event.target).data('image-large-src'));
+        $(prestashop.themeSelectors.product.modalProductCover).attr('title', $(event.target).attr('title'));
+        $(prestashop.themeSelectors.product.modalProductCover).attr('alt', $(event.target).attr('alt'));
       })
       .on('click', 'aside#thumbnails', (event) => {
         if (event.target.id === 'thumbnails') {

--- a/_dev/js/components/product-select.js
+++ b/_dev/js/components/product-select.js
@@ -48,8 +48,8 @@ export default class ProductSelect {
 
         // Get data from thumbnail and update cover sources
         updateSources(
-          $(prestashop.themeSelectors.product.modalProductCover), 
-          $(event.target).data('image-large-sources')
+          $(prestashop.themeSelectors.product.modalProductCover),
+          $(event.target).data('image-large-sources'),
         );
       })
       .on('click', 'aside#thumbnails', (event) => {

--- a/_dev/js/components/update-sources.js
+++ b/_dev/js/components/update-sources.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+import $ from 'jquery';
+
+export default function updateSources(img, sources) {
+  if (sources == undefined) {
+    return;
+  }
+
+  // Get source siblings of the img tag
+  const imgSiblingWebp = $(img).siblings('source[type="image/webp"]');
+  const imgSiblingAvif = $(img).siblings('source[type="image/avif"]');
+
+  // Update them if they exist and we have a source for them
+  if (sources.webp !== undefined && imgSiblingWebp.length) {
+    imgSiblingWebp.attr('srcset', sources.webp);
+  }
+  if (sources.avif !== undefined && imgSiblingAvif.length) {
+    imgSiblingAvif.attr('srcset', sources.avif);
+  }
+}

--- a/_dev/js/components/update-sources.js
+++ b/_dev/js/components/update-sources.js
@@ -25,7 +25,7 @@
 import $ from 'jquery';
 
 export default function updateSources(img, sources) {
-  if (sources == undefined) {
+  if (sources === undefined) {
     return;
   }
 

--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -60,15 +60,27 @@ $(document).ready(() => {
     const $arrows = $(prestashop.themeSelectors.product.arrows);
     const $thumbnails = qv.find('.js-qv-product-images');
     $(prestashop.themeSelectors.product.thumb).on('click', (event) => {
+      // Swap active classes on thumbnail
       if ($(prestashop.themeSelectors.product.thumb).hasClass('selected')) {
         $(prestashop.themeSelectors.product.thumb).removeClass('selected');
       }
       $(event.currentTarget).addClass('selected');
 
-      // Update cover source, alt and title
+      // Get data from thumbnail and update cover src, alt and title
       $(prestashop.themeSelectors.product.cover).attr('src', $(event.target).data('image-large-src'));
       $(prestashop.themeSelectors.product.cover).attr('alt', $(event.target).attr('alt'));
       $(prestashop.themeSelectors.product.cover).attr('title', $(event.target).attr('title'));
+
+      // Get data from thumbnail and update cover sources
+      const sources = $(event.target).data('image-large-sources');
+      const productCoverWebp = $(prestashop.themeSelectors.product.cover).siblings('source[type="image/webp"]');
+      const productCoverAvif = $(prestashop.themeSelectors.product.cover).siblings('source[type="image/avif"]');
+      if (sources !== undefined && sources.webp !== undefined && productCoverWebp.length) {
+        productCoverWebp.attr('srcset', sources.webp);
+      }
+      if (sources !== undefined && sources.avif !== undefined && productCoverAvif.length) {
+        productCoverAvif.attr('srcset', sources.avif);
+      }
     });
     if ($thumbnails.find('li').length <= MAX_THUMBS) {
       $arrows.hide();

--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -75,6 +75,7 @@ $(document).ready(() => {
       const sources = $(event.target).data('image-large-sources');
       const productCoverWebp = $(prestashop.themeSelectors.product.cover).siblings('source[type="image/webp"]');
       const productCoverAvif = $(prestashop.themeSelectors.product.cover).siblings('source[type="image/avif"]');
+
       if (sources !== undefined && sources.webp !== undefined && productCoverWebp.length) {
         productCoverWebp.attr('srcset', sources.webp);
       }

--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -73,8 +73,8 @@ $(document).ready(() => {
 
       // Get data from thumbnail and update cover sources
       updateSources(
-        $(prestashop.themeSelectors.product.cover), 
-        $(event.target).data('image-large-sources')
+        $(prestashop.themeSelectors.product.cover),
+        $(event.target).data('image-large-sources'),
       );
     });
     if ($thumbnails.find('li').length <= MAX_THUMBS) {

--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -26,7 +26,7 @@ import $ from 'jquery';
 import prestashop from 'prestashop';
 // eslint-disable-next-line
 import "velocity-animate";
-
+import updateSources from './components/update-sources';
 import ProductMinitature from './components/product-miniature';
 
 $(document).ready(() => {
@@ -72,16 +72,10 @@ $(document).ready(() => {
       $(prestashop.themeSelectors.product.cover).attr('title', $(event.target).attr('title'));
 
       // Get data from thumbnail and update cover sources
-      const sources = $(event.target).data('image-large-sources');
-      const productCoverWebp = $(prestashop.themeSelectors.product.cover).siblings('source[type="image/webp"]');
-      const productCoverAvif = $(prestashop.themeSelectors.product.cover).siblings('source[type="image/avif"]');
-
-      if (sources !== undefined && sources.webp !== undefined && productCoverWebp.length) {
-        productCoverWebp.attr('srcset', sources.webp);
-      }
-      if (sources !== undefined && sources.avif !== undefined && productCoverAvif.length) {
-        productCoverAvif.attr('srcset', sources.avif);
-      }
+      updateSources(
+        $(prestashop.themeSelectors.product.cover), 
+        $(event.target).data('image-large-sources')
+      );
     });
     if ($thumbnails.find('li').length <= MAX_THUMBS) {
       $arrows.hide();

--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -64,10 +64,11 @@ $(document).ready(() => {
         $(prestashop.themeSelectors.product.thumb).removeClass('selected');
       }
       $(event.currentTarget).addClass('selected');
-      $(prestashop.themeSelectors.product.cover).attr(
-        'src',
-        $(event.target).data('image-large-src'),
-      );
+
+      // Update cover source, alt and title
+      $(prestashop.themeSelectors.product.cover).attr('src', $(event.target).data('image-large-src'));
+      $(prestashop.themeSelectors.product.cover).attr('alt', $(event.target).attr('alt'));
+      $(prestashop.themeSelectors.product.cover).attr('title', $(event.target).attr('title'));
     });
     if ($thumbnails.find('li').length <= MAX_THUMBS) {
       $arrows.hide();

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -56,6 +56,7 @@ $(document).ready(() => {
       const productCoverAvif = productCover.siblings('source[type="image/avif"]');
       const modalProductCoverWebp = modalProductCover.siblings('source[type="image/webp"]');
       const modalProductCoverAvif = modalProductCover.siblings('source[type="image/avif"]');
+
       if (sourcesMedium !== undefined && sourcesMedium.webp !== undefined && productCoverWebp.length) {
         productCoverWebp.attr('srcset', sourcesMedium.webp);
       }

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -25,6 +25,7 @@
 import $ from 'jquery';
 import prestashop from 'prestashop';
 import ProductSelect from './components/product-select';
+import updateSources from './components/update-sources';
 
 $(document).ready(() => {
   function coverImage() {
@@ -50,25 +51,8 @@ $(document).ready(() => {
       modalProductCover.attr('alt', newSelectedThumb.attr('alt'));
 
       // Get data from thumbnail and update cover sources
-      const sourcesMedium = newSelectedThumb.data('image-medium-sources');
-      const sourcesLarge = newSelectedThumb.data('image-large-sources');
-      const productCoverWebp = productCover.siblings('source[type="image/webp"]');
-      const productCoverAvif = productCover.siblings('source[type="image/avif"]');
-      const modalProductCoverWebp = modalProductCover.siblings('source[type="image/webp"]');
-      const modalProductCoverAvif = modalProductCover.siblings('source[type="image/avif"]');
-
-      if (sourcesMedium !== undefined && sourcesMedium.webp !== undefined && productCoverWebp.length) {
-        productCoverWebp.attr('srcset', sourcesMedium.webp);
-      }
-      if (sourcesMedium !== undefined && sourcesMedium.avif !== undefined && productCoverAvif.length) {
-        productCoverAvif.attr('srcset', sourcesMedium.avif);
-      }
-      if (sourcesLarge !== undefined && sourcesLarge.webp !== undefined && modalProductCoverWebp.length) {
-        modalProductCoverWebp.attr('srcset', sourcesLarge.webp);
-      }
-      if (sourcesLarge !== undefined && sourcesLarge.avif !== undefined && modalProductCoverAvif.length) {
-        modalProductCoverAvif.attr('srcset', sourcesLarge.avif);
-      }
+      updateSources(productCover, newSelectedThumb.data('image-medium-sources'));
+      updateSources(modalProductCover, newSelectedThumb.data('image-large-sources'));
     };
 
     $(prestashop.themeSelectors.product.thumb).on('click', (event) => {

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -29,15 +29,25 @@ import ProductSelect from './components/product-select';
 $(document).ready(() => {
   function coverImage() {
     const productCover = $(prestashop.themeSelectors.product.cover);
+    const modalProductCover = $(prestashop.themeSelectors.product.modalProductCover);
     let thumbSelected = $(prestashop.themeSelectors.product.selected);
 
     const swipe = (selectedThumb, thumbParent) => {
       const newSelectedThumb = thumbParent.find(prestashop.themeSelectors.product.thumb);
 
-      $(prestashop.themeSelectors.product.modalProductCover).attr('src', newSelectedThumb.data('image-large-src'));
+      // Update thumbnail active classes
       selectedThumb.removeClass('selected');
       newSelectedThumb.addClass('selected');
+
+      // Update sources of both cover and modal cover
+      modalProductCover.prop('src', newSelectedThumb.data('image-large-src'));
       productCover.prop('src', newSelectedThumb.data('image-medium-src'));
+
+      // Update alt and title
+      productCover.attr('title', newSelectedThumb.attr('title'));
+      modalProductCover.attr('title', newSelectedThumb.attr('title'));
+      productCover.attr('alt', newSelectedThumb.attr('alt'));
+      modalProductCover.attr('alt', newSelectedThumb.attr('alt'));
     };
 
     $(prestashop.themeSelectors.product.thumb).on('click', (event) => {

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -35,7 +35,7 @@ $(document).ready(() => {
     const swipe = (selectedThumb, thumbParent) => {
       const newSelectedThumb = thumbParent.find(prestashop.themeSelectors.product.thumb);
 
-      // Update thumbnail active classes
+      // Swap active classes on thumbnail
       selectedThumb.removeClass('selected');
       newSelectedThumb.addClass('selected');
 
@@ -43,11 +43,31 @@ $(document).ready(() => {
       modalProductCover.prop('src', newSelectedThumb.data('image-large-src'));
       productCover.prop('src', newSelectedThumb.data('image-medium-src'));
 
-      // Update alt and title
+      // Get data from thumbnail and update cover src, alt and title
       productCover.attr('title', newSelectedThumb.attr('title'));
       modalProductCover.attr('title', newSelectedThumb.attr('title'));
       productCover.attr('alt', newSelectedThumb.attr('alt'));
       modalProductCover.attr('alt', newSelectedThumb.attr('alt'));
+
+      // Get data from thumbnail and update cover sources
+      const sourcesMedium = newSelectedThumb.data('image-medium-sources');
+      const sourcesLarge = newSelectedThumb.data('image-large-sources');
+      const productCoverWebp = productCover.siblings('source[type="image/webp"]');
+      const productCoverAvif = productCover.siblings('source[type="image/avif"]');
+      const modalProductCoverWebp = modalProductCover.siblings('source[type="image/webp"]');
+      const modalProductCoverAvif = modalProductCover.siblings('source[type="image/avif"]');
+      if (sourcesMedium !== undefined && sourcesMedium.webp !== undefined && productCoverWebp.length) {
+        productCoverWebp.attr('srcset', sourcesMedium.webp);
+      }
+      if (sourcesMedium !== undefined && sourcesMedium.avif !== undefined && productCoverAvif.length) {
+        productCoverAvif.attr('srcset', sourcesMedium.avif);
+      }
+      if (sourcesLarge !== undefined && sourcesLarge.webp !== undefined && modalProductCoverWebp.length) {
+        modalProductCoverWebp.attr('srcset', sourcesLarge.webp);
+      }
+      if (sourcesLarge !== undefined && sourcesLarge.avif !== undefined && modalProductCoverAvif.length) {
+        modalProductCoverAvif.attr('srcset', sourcesLarge.avif);
+      }
     };
 
     $(prestashop.themeSelectors.product.thumb).on('click', (event) => {

--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -32,7 +32,11 @@
                 {/if}
                 {if !empty($category.image.large.url)}
                     <div class="category-cover">
-                        <img src="{$category.image.large.url}" alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" loading="lazy" width="141" height="180">
+                        <picture>
+                            {if !empty($category.image.large.sources.avif)}<source srcset="{$category.image.large.sources.avif}" type="image/avif">{/if}
+                            {if !empty($category.image.large.sources.webp)}<source srcset="{$category.image.large.sources.webp}" type="image/webp">{/if}
+                            <img src="{$category.image.large.url}" alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" loading="lazy" width="141" height="180">
+                        </picture>
                     </div>
                 {/if}
             </div>

--- a/templates/catalog/_partials/miniatures/category.tpl
+++ b/templates/catalog/_partials/miniatures/category.tpl
@@ -25,13 +25,17 @@
 {block name='category_miniature_item'}
   <section class="category-miniature">
     <a href="{$category.url}">
-      <img
-        src="{$category.image.medium.url}"
-        alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}"
-        loading="lazy"
-        width="250"
-        height="250"
-      >
+      <picture>
+        {if !empty($category.image.medium.sources.avif)}<source srcset="{$category.image.medium.sources.avif}" type="image/avif">{/if}
+        {if !empty($category.image.medium.sources.webp)}<source srcset="{$category.image.medium.sources.webp}" type="image/webp">{/if}
+        <img
+          src="{$category.image.medium.url}"
+          alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}"
+          loading="lazy"
+          width="250"
+          height="250"
+        >
+      </picture>
     </a>
 
     <h1 class="h2">

--- a/templates/catalog/_partials/miniatures/pack-product.tpl
+++ b/templates/catalog/_partials/miniatures/pack-product.tpl
@@ -30,19 +30,27 @@
           <div class="mask">
             <a href="{$product.url}" title="{$product.name}">
               {if !empty($product.default_image.medium)}
-                <img
-                        src="{$product.default_image.medium.url}"
-                        {if !empty($product.default_image.legend)}
-                          alt="{$product.default_image.legend}"
-                          title="{$product.default_image.legend}"
-                        {else}
-                          alt="{$product.name}"
-                        {/if}
-                        loading="lazy"
-                        data-full-size-image-url="{$product.default_image.large.url}"
-                >
+                <picture>
+                  {if !empty($product.default_image.medium.sources.avif)}<source srcset="{$product.default_image.medium.sources.avif}" type="image/avif">{/if}
+                  {if !empty($product.default_image.medium.sources.webp)}<source srcset="{$product.default_image.medium.sources.webp}" type="image/webp">{/if}
+                  <img
+                          src="{$product.default_image.medium.url}"
+                          {if !empty($product.default_image.legend)}
+                            alt="{$product.default_image.legend}"
+                            title="{$product.default_image.legend}"
+                          {else}
+                            alt="{$product.name}"
+                          {/if}
+                          loading="lazy"
+                          data-full-size-image-url="{$product.default_image.large.url}"
+                  >
+                </picture>
               {else}
-                <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" />
+                <picture>
+                  {if !empty($urls.no_picture_image.bySize.medium_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.medium_default.sources.avif}" type="image/avif">{/if}
+                  {if !empty($urls.no_picture_image.bySize.medium_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.medium_default.sources.webp}" type="image/webp">{/if}
+                  <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" />
+                </picture>
               {/if}
             </a>
           </div>

--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -30,23 +30,31 @@
         {block name='product_thumbnail'}
           {if $product.cover}
             <a href="{$product.url}" class="thumbnail product-thumbnail">
-              <img
-                src="{$product.cover.bySize.home_default.url}"
-                alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
-                loading="lazy"
-                data-full-size-image-url="{$product.cover.large.url}"
-                width="{$product.cover.bySize.home_default.width}"
-                height="{$product.cover.bySize.home_default.height}"
-              />
+              <picture>
+                {if !empty($product.cover.bySize.home_default.sources.avif)}<source srcset="{$product.cover.bySize.home_default.sources.avif}" type="image/avif">{/if}
+                {if !empty($product.cover.bySize.home_default.sources.webp)}<source srcset="{$product.cover.bySize.home_default.sources.webp}" type="image/webp">{/if}
+                <img
+                  src="{$product.cover.bySize.home_default.url}"
+                  alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
+                  loading="lazy"
+                  data-full-size-image-url="{$product.cover.large.url}"
+                  width="{$product.cover.bySize.home_default.width}"
+                  height="{$product.cover.bySize.home_default.height}"
+                />
+              </picture>
             </a>
           {else}
             <a href="{$product.url}" class="thumbnail product-thumbnail">
-              <img
-                src="{$urls.no_picture_image.bySize.home_default.url}"
-                loading="lazy"
-                width="{$urls.no_picture_image.bySize.home_default.width}"
-                height="{$urls.no_picture_image.bySize.home_default.height}"
-              />
+              <picture>
+                {if !empty($urls.no_picture_image.bySize.home_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.home_default.sources.avif}" type="image/avif">{/if}
+                {if !empty($urls.no_picture_image.bySize.home_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.home_default.sources.webp}" type="image/webp">{/if}
+                <img
+                  src="{$urls.no_picture_image.bySize.home_default.url}"
+                  loading="lazy"
+                  width="{$urls.no_picture_image.bySize.home_default.width}"
+                  height="{$urls.no_picture_image.bySize.home_default.height}"
+                />
+              </picture>
             </a>
           {/if}
         {/block}

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -26,30 +26,38 @@
   {block name='product_cover'}
     <div class="product-cover">
       {if $product.default_image}
-        <img
-          class="js-qv-product-cover img-fluid"
-          src="{$product.default_image.bySize.large_default.url}"
-          {if !empty($product.default_image.legend)}
-            alt="{$product.default_image.legend}"
-            title="{$product.default_image.legend}"
-          {else}
-            alt="{$product.name}"
-          {/if}
-          loading="lazy"
-          width="{$product.default_image.bySize.large_default.width}"
-          height="{$product.default_image.bySize.large_default.height}"
-        >
+        <picture>
+          {if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+          <img
+            class="js-qv-product-cover img-fluid"
+            src="{$product.default_image.bySize.large_default.url}"
+            {if !empty($product.default_image.legend)}
+              alt="{$product.default_image.legend}"
+              title="{$product.default_image.legend}"
+            {else}
+              alt="{$product.name}"
+            {/if}
+            loading="lazy"
+            width="{$product.default_image.bySize.large_default.width}"
+            height="{$product.default_image.bySize.large_default.height}"
+          >
+        </picture>
         <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
           <i class="material-icons zoom-in">search</i>
         </div>
       {else}
-        <img
-          class="img-fluid"
-          src="{$urls.no_picture_image.bySize.medium_default.url}"
-          loading="lazy"
-          width="{$urls.no_picture_image.bySize.medium_default.width}"
-          height="{$urls.no_picture_image.bySize.medium_default.height}"
-        >
+        <picture>
+          {if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+          <img
+            class="img-fluid"
+            src="{$urls.no_picture_image.bySize.large_default.url}"
+            loading="lazy"
+            width="{$urls.no_picture_image.bySize.large_default.width}"
+            height="{$urls.no_picture_image.bySize.large_default.height}"
+          >
+        </picture>
       {/if}
     </div>
   {/block}
@@ -59,21 +67,25 @@
       <ul class="product-images js-qv-product-images">
         {foreach from=$product.images item=image}
           <li class="thumb-container js-thumb-container">
-            <img
-              class="thumb js-thumb {if $image.id_image == $product.default_image.id_image} selected js-thumb-selected {/if}"
-              data-image-medium-src="{$image.bySize.medium_default.url}"
-              data-image-large-src="{$image.bySize.large_default.url}"
-              src="{$image.bySize.small_default.url}"
-              {if !empty($image.legend)}
-                alt="{$image.legend}"
-                title="{$image.legend}"
-              {else}
-                alt="{$product.name}"
-              {/if}
-              loading="lazy"
-              width="{$product.default_image.bySize.small_default.width}"
-              height="{$product.default_image.bySize.small_default.height}"
-            >
+            <picture>
+              {if !empty($image.bySize.small_default.sources.avif)}<source srcset="{$image.bySize.small_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($image.bySize.small_default.sources.webp)}<source srcset="{$image.bySize.small_default.sources.webp}" type="image/webp">{/if}
+              <img
+                class="thumb js-thumb {if $image.id_image == $product.default_image.id_image} selected js-thumb-selected {/if}"
+                data-image-medium-src="{$image.bySize.medium_default.url}"
+                data-image-large-src="{$image.bySize.large_default.url}"
+                src="{$image.bySize.small_default.url}"
+                {if !empty($image.legend)}
+                  alt="{$image.legend}"
+                  title="{$image.legend}"
+                {else}
+                  alt="{$product.name}"
+                {/if}
+                loading="lazy"
+                width="{$product.default_image.bySize.small_default.width}"
+                height="{$product.default_image.bySize.small_default.height}"
+              >
+            </picture>
           </li>
         {/foreach}
       </ul>

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -27,8 +27,8 @@
     <div class="product-cover">
       {if $product.default_image}
         <picture>
-          {*{if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-          {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
+          {if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
           <img
             class="js-qv-product-cover img-fluid"
             src="{$product.default_image.bySize.large_default.url}"
@@ -48,8 +48,8 @@
         </div>
       {else}
         <picture>
-          {*{if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-          {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
+          {if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
           <img
             class="img-fluid"
             src="{$urls.no_picture_image.bySize.large_default.url}"

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -73,9 +73,9 @@
               <img
                 class="thumb js-thumb {if $image.id_image == $product.default_image.id_image} selected js-thumb-selected {/if}"
                 data-image-medium-src="{$image.bySize.medium_default.url}"
-                data-image-medium-sources="{$image.bySize.medium_default.sources|@json_encode}"
+                {if !empty($image.bySize.medium_default.sources)}data-image-medium-sources="{$image.bySize.medium_default.sources|@json_encode}"{/if}
                 data-image-large-src="{$image.bySize.large_default.url}"
-                data-image-large-sources="{$image.bySize.large_default.sources|@json_encode}"
+                {if !empty($image.bySize.large_default.sources)}data-image-large-sources="{$image.bySize.large_default.sources|@json_encode}"{/if}
                 src="{$image.bySize.small_default.url}"
                 {if !empty($image.legend)}
                   alt="{$image.legend}"

--- a/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -27,8 +27,8 @@
     <div class="product-cover">
       {if $product.default_image}
         <picture>
-          {if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-          {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+          {*{if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
           <img
             class="js-qv-product-cover img-fluid"
             src="{$product.default_image.bySize.large_default.url}"
@@ -48,8 +48,8 @@
         </div>
       {else}
         <picture>
-          {if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-          {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+          {*{if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
           <img
             class="img-fluid"
             src="{$urls.no_picture_image.bySize.large_default.url}"
@@ -73,7 +73,9 @@
               <img
                 class="thumb js-thumb {if $image.id_image == $product.default_image.id_image} selected js-thumb-selected {/if}"
                 data-image-medium-src="{$image.bySize.medium_default.url}"
+                data-image-medium-sources="{$image.bySize.medium_default.sources|@json_encode}"
                 data-image-large-src="{$image.bySize.large_default.url}"
+                data-image-large-sources="{$image.bySize.large_default.sources|@json_encode}"
                 src="{$image.bySize.small_default.url}"
                 {if !empty($image.legend)}
                   alt="{$image.legend}"

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -29,20 +29,28 @@
         {assign var=imagesCount value=$product.images|count}
         <figure>
           {if $product.default_image}
-            <img
-              class="js-modal-product-cover product-cover-modal"
-              width="{$product.default_image.bySize.large_default.width}"
-              src="{$product.default_image.bySize.large_default.url}"
-              {if !empty($product.default_image.legend)}
-                alt="{$product.default_image.legend}"
-                title="{$product.default_image.legend}"
-              {else}
-                alt="{$product.name}"
-              {/if}
-              height="{$product.default_image.bySize.large_default.height}"
-            >
+            <picture>
+              {if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+              <img
+                class="js-modal-product-cover product-cover-modal"
+                width="{$product.default_image.bySize.large_default.width}"
+                src="{$product.default_image.bySize.large_default.url}"
+                {if !empty($product.default_image.legend)}
+                  alt="{$product.default_image.legend}"
+                  title="{$product.default_image.legend}"
+                {else}
+                  alt="{$product.name}"
+                {/if}
+                height="{$product.default_image.bySize.large_default.height}"
+              >
+            </picture>
           {else}
-            <img src="{$urls.no_picture_image.bySize.large_default.url}" loading="lazy" width="{$urls.no_picture_image.bySize.large_default.width}" height="{$urls.no_picture_image.bySize.large_default.height}" />
+            <picture>
+              {if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+              <img src="{$urls.no_picture_image.bySize.large_default.url}" loading="lazy" width="{$urls.no_picture_image.bySize.large_default.width}" height="{$urls.no_picture_image.bySize.large_default.height}" />
+            </picture>
           {/if}
           <figcaption class="image-caption">
           {block name='product_description_short'}
@@ -56,19 +64,23 @@
               <ul class="product-images js-modal-product-images">
                 {foreach from=$product.images item=image}
                   <li class="thumb-container js-thumb-container">
-                    <img
-                      data-image-large-src="{$image.large.url}"
-                      class="thumb js-modal-thumb"
-                      src="{$image.medium.url}"
-                      {if !empty($image.legend)}
-                        alt="{$image.legend}"
-                        title="{$image.legend}"
-                      {else}
-                        alt="{$product.name}"
-                      {/if}
-                      width="{$image.medium.width}"
-                      height="148"
-                    >
+                    <picture>
+                      {if !empty($image.medium.sources.avif)}<source srcset="{$image.medium.sources.avif}" type="image/avif">{/if}
+                      {if !empty($image.medium.sources.webp)}<source srcset="{$image.medium.sources.webp}" type="image/webp">{/if}
+                      <img
+                        data-image-large-src="{$image.large.url}"
+                        class="thumb js-modal-thumb"
+                        src="{$image.medium.url}"
+                        {if !empty($image.legend)}
+                          alt="{$image.legend}"
+                          title="{$image.legend}"
+                        {else}
+                          alt="{$product.name}"
+                        {/if}
+                        width="{$image.medium.width}"
+                        height="148"
+                      >
+                    </picture>
                   </li>
                 {/foreach}
               </ul>

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -69,7 +69,7 @@
                       {if !empty($image.medium.sources.webp)}<source srcset="{$image.medium.sources.webp}" type="image/webp">{/if}
                       <img
                         data-image-large-src="{$image.large.url}"
-                        data-image-large-sources="{$image.large.sources|@json_encode}"
+                        {if !empty($image.large.sources)}data-image-large-sources="{$image.large.sources|@json_encode}"{/if}
                         class="thumb js-modal-thumb"
                         src="{$image.medium.url}"
                         {if !empty($image.legend)}

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -30,8 +30,8 @@
         <figure>
           {if $product.default_image}
             <picture>
-              {*{if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-              {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
+              {if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
               <img
                 class="js-modal-product-cover product-cover-modal"
                 width="{$product.default_image.bySize.large_default.width}"
@@ -47,8 +47,8 @@
             </picture>
           {else}
             <picture>
-              {*{if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-              {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
+              {if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
               <img src="{$urls.no_picture_image.bySize.large_default.url}" loading="lazy" width="{$urls.no_picture_image.bySize.large_default.width}" height="{$urls.no_picture_image.bySize.large_default.height}" />
             </picture>
           {/if}

--- a/templates/catalog/_partials/product-images-modal.tpl
+++ b/templates/catalog/_partials/product-images-modal.tpl
@@ -30,8 +30,8 @@
         <figure>
           {if $product.default_image}
             <picture>
-              {if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-              {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+              {*{if !empty($product.default_image.bySize.large_default.sources.avif)}<source srcset="{$product.default_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($product.default_image.bySize.large_default.sources.webp)}<source srcset="{$product.default_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
               <img
                 class="js-modal-product-cover product-cover-modal"
                 width="{$product.default_image.bySize.large_default.width}"
@@ -47,8 +47,8 @@
             </picture>
           {else}
             <picture>
-              {if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
-              {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}
+              {*{if !empty($urls.no_picture_image.bySize.large_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($urls.no_picture_image.bySize.large_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.large_default.sources.webp}" type="image/webp">{/if}*}
               <img src="{$urls.no_picture_image.bySize.large_default.url}" loading="lazy" width="{$urls.no_picture_image.bySize.large_default.width}" height="{$urls.no_picture_image.bySize.large_default.height}" />
             </picture>
           {/if}
@@ -69,6 +69,7 @@
                       {if !empty($image.medium.sources.webp)}<source srcset="{$image.medium.sources.webp}" type="image/webp">{/if}
                       <img
                         data-image-large-src="{$image.large.url}"
+                        data-image-large-sources="{$image.large.sources|@json_encode}"
                         class="thumb js-modal-thumb"
                         src="{$image.medium.url}"
                         {if !empty($image.legend)}

--- a/templates/catalog/_partials/subcategories.tpl
+++ b/templates/catalog/_partials/subcategories.tpl
@@ -33,13 +33,17 @@
             <div class="subcategory-image">
               <a href="{$subcategory.url}" title="{$subcategory.name|escape:'html':'UTF-8'}" class="img">
                 {if !empty($subcategory.image.large.url)}
-                  <img
-                    class="img-fluid"
-                    src="{$subcategory.image.large.url}"
-                    alt="{$subcategory.name|escape:'html':'UTF-8'}"
-                    loading="lazy"
-                    width="{$subcategory.image.large.width}"
-                    height="{$subcategory.image.large.height}"/>
+                  <picture>
+                    {if !empty($subcategory.image.large.sources.avif)}<source srcset="{$subcategory.image.large.sources.avif}" type="image/avif">{/if}
+                    {if !empty($subcategory.image.large.sources.webp)}<source srcset="{$subcategory.image.large.sources.webp}" type="image/webp">{/if}
+                    <img
+                      class="img-fluid"
+                      src="{$subcategory.image.large.url}"
+                      alt="{$subcategory.name|escape:'html':'UTF-8'}"
+                      loading="lazy"
+                      width="{$subcategory.image.large.width}"
+                      height="{$subcategory.image.large.height}"/>
+                  </picture>
                 {/if}
               </a>
             </div>

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -27,9 +27,17 @@
   <div class="product-line-grid-left col-md-3 col-xs-4">
     <span class="product-image media-middle">
       {if $product.default_image}
-        <img src="{$product.default_image.bySize.cart_default.url}" alt="{$product.name|escape:'quotes'}" loading="lazy">
+        <picture>
+          {if !empty($product.default_image.bySize.cart_default.sources.avif)}<source srcset="{$product.default_image.bySize.cart_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($product.default_image.bySize.cart_default.sources.webp)}<source srcset="{$product.default_image.bySize.cart_default.sources.webp}" type="image/webp">{/if}
+          <img src="{$product.default_image.bySize.cart_default.url}" alt="{$product.name|escape:'quotes'}" loading="lazy">
+        </picture>
       {else}
-        <img src="{$urls.no_picture_image.bySize.cart_default.url}" loading="lazy" />
+        <picture>
+          {if !empty($urls.no_picture_image.bySize.cart_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.cart_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($urls.no_picture_image.bySize.cart_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.cart_default.sources.webp}" type="image/webp">{/if}
+          <img src="{$urls.no_picture_image.bySize.cart_default.url}" loading="lazy" />
+        </picture>
       {/if}
     </span>
   </div>

--- a/templates/checkout/_partials/cart-summary-product-line.tpl
+++ b/templates/checkout/_partials/cart-summary-product-line.tpl
@@ -26,9 +26,17 @@
   <div class="media-left">
     <a href="{$product.url}" title="{$product.name}">
       {if $product.default_image}
-        <img class="media-object" src="{$product.default_image.small.url}" alt="{$product.name}" loading="lazy">
+        <picture>
+          {if !empty($product.default_image.small.sources.avif)}<source srcset="{$product.default_image.small.sources.avif}" type="image/avif">{/if}
+          {if !empty($product.default_image.small.sources.webp)}<source srcset="{$product.default_image.small.sources.webp}" type="image/webp">{/if}
+          <img class="media-object" src="{$product.default_image.small.url}" alt="{$product.name}" loading="lazy">
+        </picture>
       {else}
-        <img src="{$urls.no_picture_image.bySize.small_default.url}" loading="lazy" />
+        <picture>
+          {if !empty($urls.no_picture_image.bySize.small_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.small_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($urls.no_picture_image.bySize.small_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.small_default.sources.webp}" type="image/webp">{/if}
+          <img src="{$urls.no_picture_image.bySize.small_default.url}" loading="lazy" />
+        </picture>
       {/if}
     </a>
   </div>

--- a/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/templates/checkout/_partials/order-confirmation-table.tpl
@@ -40,9 +40,17 @@
           <div class="col-sm-2 col-xs-3">
             <span class="image">
               {if !empty($product.default_image)}
-                <img src="{$product.default_image.medium.url}" loading="lazy" />
+                <picture>
+                  {if !empty($product.default_image.medium.sources.avif)}<source srcset="{$product.default_image.medium.sources.avif}" type="image/avif">{/if}
+                  {if !empty($product.default_image.medium.sources.webp)}<source srcset="{$product.default_image.medium.sources.webp}" type="image/webp">{/if}
+                  <img src="{$product.default_image.medium.url}" loading="lazy" />
+                </picture>
               {else}
-                <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" />
+                <picture>
+                  {if !empty($urls.no_picture_image.bySize.medium_default.sources.avif)}<source srcset="{$urls.no_picture_image.bySize.medium_default.sources.avif}" type="image/avif">{/if}
+                  {if !empty($urls.no_picture_image.bySize.medium_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.medium_default.sources.webp}" type="image/webp">{/if}
+                  <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" />
+                </picture>
               {/if}
             </span>
           </div>

--- a/templates/cms/stores.tpl
+++ b/templates/cms/stores.tpl
@@ -35,15 +35,19 @@
       <article id="store-{$store.id}" class="store-item card">
         <div class="store-item-container clearfix">
           <div class="col-md-3 store-picture hidden-sm-down">
-            <img
-              src="{$store.image.bySize.stores_default.url}"
-              {if !empty($store.image.legend)}
-                alt="{$store.image.legend}"
-                title="{$store.image.legend}"
-              {else}
-                alt="{$store.name}"
-              {/if}
-            >
+            <picture>
+              {if !empty($store.image.bySize.stores_default.sources.avif)}<source srcset="{$store.image.bySize.stores_default.sources.avif}" type="image/avif">{/if}
+              {if !empty($store.image.bySize.stores_default.sources.webp)}<source srcset="{$store.image.bySize.stores_default.sources.webp}" type="image/webp">{/if}
+              <img
+                src="{$store.image.bySize.stores_default.url}"
+                {if !empty($store.image.legend)}
+                  alt="{$store.image.legend}"
+                  title="{$store.image.legend}"
+                {else}
+                  alt="{$store.name}"
+                {/if}
+              >
+            </picture>
           </div>
           <div class="col-md-5 col-sm-7 col-xs-12 store-description">
             <p class="h3 card-title">{$store.name}</p>


### PR DESCRIPTION
**This should go to 2.1.x and develop.**

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This implements picture tags where possible and adds webp+avif sources, if available. Adds sources info to JS attributes to use it in JS. Change image titles and alts properly.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | See below

### What to ignore during testing
- Picture tags are implemented only on images where the sources were provided. Exceptions are for example:
  - Manufacturer logo on product page, manufacturer images in manufacturers page, supplier listing. This will be fixed by introducing a manufacturer presenter.
- It does not work correctly for category images and store images, they may contain JPG links inside the webp sources. It will be fixed by https://github.com/PrestaShop/PrestaShop/pull/31310. However, the code is there and prepared. 👍

### How to test
- Add some images to a product and fill legends to those images.
- Go to product page and inspect product main image.
- See that there is a picture tag now with the img tag inside.
- See that if you click thumbnails, the ALT and TITLE attributes of the IMG tag are now changing properly.
- See that if you enable the new image system in BO and enable JPG and WEBP, you will see the webp appear as a source tag inside the picture tag.
- See that if you click thumbnails now, it changes also the source tags.
- Also go to stores list and try to inspect an image of some store. You will see that it's now a picture tag with img and sources inside. The webp/png/avif sources may contain jpg links, depending on if https://github.com/PrestaShop/PrestaShop/pull/31310 is merged or not.

### Video
https://user-images.githubusercontent.com/6097524/217795030-07ec30b8-492a-4503-a00e-76aac00381f0.mp4