### PR TITLE
Adapt theme to dynamic sitemap URLs

### DIFF
--- a/templates/cms/sitemap.tpl
+++ b/templates/cms/sitemap.tpl
@@ -30,23 +30,13 @@
 
 {block name='page_content_container'}
   <div class="container-fluid">
-    <div class="row sitemap col-xs-12">
+    <div class="row sitemap">
+      {foreach $sitemapUrls as $group}
         <div class="col-md-3">
-          <h2>{$our_offers}</h2>
-          {include file='cms/_partials/sitemap-nested-list.tpl' links=$links.offers}
+          <h2>{$group.name}</h2>
+          {include file='cms/_partials/sitemap-nested-list.tpl' links=$group.links}
         </div>
-        <div class="col-md-3">
-          <h2>{$categories}</h2>
-          {include file='cms/_partials/sitemap-nested-list.tpl' links=$links.categories}
-        </div>
-        <div class="col-md-3">
-          <h2>{$your_account}</h2>
-          {include file='cms/_partials/sitemap-nested-list.tpl' links=$links.user_account}
-        </div>
-        <div class="col-md-3">
-          <h2>{$pages}</h2>
-          {include file='cms/_partials/sitemap-nested-list.tpl' links=$links.pages}
-        </div>
+      {/foreach}
     </div>
   </div>
 {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adapts theme to use dynamic URLs in sitemap. PR will work after merging https://github.com/PrestaShop/PrestaShop/pull/31620.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #https://github.com/PrestaShop/PrestaShop/pull/29797
| Sponsor company   | 
| How to test?      | Merge that PR, check sitemap page and see that it looks the same.