### PR TITLE
Adapt template for manufacturer presenter

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -1,6 +1,6 @@
 name: classic
 display_name: Classic
-version: 2.1.0
+version: 3.0.0
 author:
   name: "PrestaShop SA and Contributors"
   email: "contact@prestashop.com"
@@ -8,7 +8,7 @@ author:
 
 meta:
   compatibility:
-    from: 8.0.0
+    from: 9.0.0
     to: ~
 
   available_layouts:

--- a/templates/catalog/_partials/miniatures/brand.tpl
+++ b/templates/catalog/_partials/miniatures/brand.tpl
@@ -24,13 +24,34 @@
  *}
 {block name='brand_miniature_item'}
   <li class="brand">
-    <div class="brand-img"><a href="{$brand.url}"><img src="{$brand.image}" alt="{$brand.name}" loading="lazy"></a></div>
+    <div class="brand-img">
+      <a href="{$brand.url}">
+        <picture>
+          {if !empty($brand.image.bySize.small_default.sources.avif)}<source srcset="{$brand.image.bySize.small_default.sources.avif}" type="image/avif">{/if}
+          {if !empty($brand.image.bySize.small_default.sources.webp)}<source srcset="{$brand.image.bySize.small_default.sources.webp}" type="image/webp">{/if}
+          <img
+            src="{$brand.image.bySize.small_default.url}"
+            alt="{if !empty($brand.image.legend)}{$brand.image.legend}{else}{$brand.name}{/if}"
+            class="img-fluid"
+            loading="lazy"
+          >
+        </picture>
+      </a>
+    </div>
     <div class="brand-infos">
       <p><a href="{$brand.url}">{$brand.name}</a></p>
       {$brand.text nofilter}
     </div>
     <div class="brand-products">
-      <a href="{$brand.url}">{$brand.nb_products}</a>
+      <a href="{$brand.url}">
+        {if $brand.nb_products > 1}
+          {l s='%number% products' d='Shop.Theme.Catalog' sprintf=['%number%' => $brand.nb_products]}
+        {elseif $brand.nb_products == 1}
+          {l s='%number% product' d='Shop.Theme.Catalog' sprintf=['%number%' => $brand.nb_products]}
+        {else}
+          {l s='No products' d='Shop.Theme.Catalog'}
+        {/if}
+      </a>
       <a href="{$brand.url}">{l s='View products' d='Shop.Theme.Actions'}</a>
     </div>
   </li>

--- a/templates/catalog/_partials/product-details.tpl
+++ b/templates/catalog/_partials/product-details.tpl
@@ -4,16 +4,26 @@
      role="tabpanel"
   >
   {block name='product_reference'}
-    {if isset($product_manufacturer->id)}
+    {if !empty($product_manufacturer.id)}
       <div class="product-manufacturer">
-        {if isset($manufacturer_image_url)}
-          <a href="{$product_brand_url}">
-            <img src="{$manufacturer_image_url}" class="img img-fluid manufacturer-logo" alt="{$product_manufacturer->name}" loading="lazy">
+        {assign var="product_manufacturer_image_key" value="`$product_manufacturer.id`-"}
+        {if !empty($product_manufacturer.image.small.url) && strpos($product_manufacturer.image.small.url, $product_manufacturer_image_key)}
+          <a href="{$product_manufacturer.url}">
+            <picture>
+              {if !empty($product_manufacturer.image.small.sources.avif)}<source srcset="{$product_manufacturer.image.small.sources.avif}" type="image/avif">{/if}
+              {if !empty($product_manufacturer.image.small.sources.webp)}<source srcset="{$product_manufacturer.image.small.sources.webp}" type="image/webp">{/if}
+              <img
+                src="{$product_manufacturer.image.small.url}"
+                alt="{if !empty($product_manufacturer.image.legend)}{$product_manufacturer.image.legend}{else}{$product_manufacturer.name}{/if}"
+                class="img img-fluid manufacturer-logo"
+                loading="lazy"
+              >
+            </picture>
           </a>
         {else}
           <label class="label">{l s='Brand' d='Shop.Theme.Catalog'}</label>
           <span>
-            <a href="{$product_brand_url}">{$product_manufacturer->name}</a>
+            <a href="{$product_manufacturer.url}">{$product_manufacturer.name}</a>
           </span>
         {/if}
       </div>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Template modification for https://github.com/PrestaShop/PrestaShop/pull/31309. Allows use of standard image arrays and new image formats.
| Type?             | refactor
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | Install https://github.com/PrestaShop/PrestaShop/pull/31309, install this. See that it works and you have <picture> tags on /brands and on manufacturer image on product page.
