### PR TITLE
Fixes contact page responsive

### DIFF
--- a/templates/contact.tpl
+++ b/templates/contact.tpl
@@ -28,13 +28,13 @@
 
 {if $layout === 'layouts/layout-left-column.tpl'}
   {block name="left_column"}
-    <div id="left-column" class="col-xs-12 col-sm-4 col-md-3">
+    <div id="left-column" class="col-xs-12 col-md-4 col-lg-3">
       {hook h='displayContactLeftColumn'}
     </div>
   {/block}
 {else if $layout === 'layouts/layout-right-column.tpl'}
   {block name="right_column"}
-    <div id="right-column" class="col-xs-12 col-sm-4 col-md-3">
+    <div id="right-column" class="col-xs-12 col-md-4 col-lg-3">
       {hook h='displayContactRightColumn'}
     </div>
   {/block}


### PR DESCRIPTION
See previous discussion here #122

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Changed col classes that were causing a responsive issue on 767px to 567px screen sizes. `col-sm-4` was changed to` col-md-4 `and `col-md-3` was changed to `col-lg-3`.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes  [#33415](https://github.com/PrestaShop/PrestaShop/issues/33415)
| Sponsor company   | Not applicable
| How to test?      | See ticket. Navigate to Contact us page  -> Use responsive mode, click F12 -> Shrink the window to width 650px -> See fix > columns now display correctly in tablet.
