### PR TITLE
Changed size with dynamic values and lazy loading with fetchpriority

### DIFF
--- a/templates/catalog/_partials/category-header.tpl
+++ b/templates/catalog/_partials/category-header.tpl
@@ -35,7 +35,7 @@
                         <picture>
                             {if !empty($category.image.large.sources.avif)}<source srcset="{$category.image.large.sources.avif}" type="image/avif">{/if}
                             {if !empty($category.image.large.sources.webp)}<source srcset="{$category.image.large.sources.webp}" type="image/webp">{/if}
-                            <img src="{$category.image.large.url}" alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" loading="lazy" width="141" height="180">
+                            <img src="{$category.image.large.url}" alt="{if !empty($category.image.legend)}{$category.image.legend}{else}{$category.name}{/if}" fetchpriority="high" width="{$category.image.large.width}" height="{$category.image.large.height}">
                         </picture>
                     </div>
                 {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Width and height can't be static but depends on image resize so I have changed it with dynamic values coming from controller. I have also changed the lazy loading with the attribute fetchpriority=high because, with new SEO standard we except that the cover image, ideally is in the visible First Contentful Paint and we need to load category cover image as soon as possible, to distinguish other images from cover we need to tell what to load first thanks with this attribute.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | At page load we can see new values, testing the page with Google audit we notice that in network the cover image is loaded before other images.
