### PR TITLE
Added missing width and height to image on Product Pack

### DIFF
--- a/templates/catalog/_partials/miniatures/pack-product.tpl
+++ b/templates/catalog/_partials/miniatures/pack-product.tpl
@@ -35,6 +35,8 @@
                   {if !empty($product.default_image.medium.sources.webp)}<source srcset="{$product.default_image.medium.sources.webp}" type="image/webp">{/if}
                   <img
                           src="{$product.default_image.medium.url}"
+                          width="{$product.default_image.bySize.medium_default.width}"
+                          height="{$product.default_image.bySize.medium_default.height}"
                           {if !empty($product.default_image.legend)}
                             alt="{$product.default_image.legend}"
                             title="{$product.default_image.legend}"

--- a/templates/catalog/_partials/miniatures/pack-product.tpl
+++ b/templates/catalog/_partials/miniatures/pack-product.tpl
@@ -35,8 +35,8 @@
                   {if !empty($product.default_image.medium.sources.webp)}<source srcset="{$product.default_image.medium.sources.webp}" type="image/webp">{/if}
                   <img
                           src="{$product.default_image.medium.url}"
-                          width="{$product.default_image.bySize.medium_default.width}"
-                          height="{$product.default_image.bySize.medium_default.height}"
+                          width="{$product.default_image.medium.width}"
+                          height="{$product.default_image.medium.height}"
                           {if !empty($product.default_image.legend)}
                             alt="{$product.default_image.legend}"
                             title="{$product.default_image.legend}"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | I have added missing attribute width and height to product pack miniature to prevent CLS and improve Web Vitals
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
