### PR TITLE
Improve LCP on product miniature with fetchpriority

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -36,7 +36,7 @@
                 <img
                   src="{$product.cover.bySize.home_default.url}"
                   alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
-                  loading="lazy"
+                  {if isset($position) && $position < 4}fetchpriority="high"{else}loading="lazy"{/if}
                   data-full-size-image-url="{$product.cover.large.url}"
                   width="{$product.cover.bySize.home_default.width}"
                   height="{$product.cover.bySize.home_default.height}"
@@ -50,7 +50,7 @@
                 {if !empty($urls.no_picture_image.bySize.home_default.sources.webp)}<source srcset="{$urls.no_picture_image.bySize.home_default.sources.webp}" type="image/webp">{/if}
                 <img
                   src="{$urls.no_picture_image.bySize.home_default.url}"
-                  loading="lazy"
+                  {if isset($position) && $position < 4}fetchpriority="high"{else}loading="lazy"{/if}
                   width="{$urls.no_picture_image.bySize.home_default.width}"
                   height="{$urls.no_picture_image.bySize.home_default.height}"
                 />


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | In a Category listing page, if we set all miniature product images with loading=lazy we got an LCP issue because for sure the LCP is a miniature product image, in most cases. If we load first 4 images with fetchpriority=high we just tell to browser to load these images first and we fix the LCP issue and improve Web Vitals.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
