### PR TITLE
Fix: The new password policy is not present in the reset password

### DIFF
--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -55,7 +55,16 @@
           <div class="row form-group">
             <label class="form-control-label col-md-3 offset-md-2">{l s='New password' d='Shop.Forms.Labels'}</label>
             <div class="col-md-4 js-input-column">
-              <input class="form-control" type="password" data-validate="isPasswd" name="passwd" value="">
+            <input
+              class="form-control"
+              type="password"
+              data-validate="isPasswd"
+              name="passwd"
+              value=""
+              {if isset($configuration.password_policy.minimum_length)}data-minlength="{$configuration.password_policy.minimum_length}"{/if}
+              {if isset($configuration.password_policy.maximum_length)}data-maxlength="{$configuration.password_policy.maximum_length}"{/if}
+              {if isset($configuration.password_policy.minimum_score)}data-minscore="{$configuration.password_policy.minimum_score}"{/if}
+            >
             </div>
           </div>
 

--- a/templates/customer/password-new.tpl
+++ b/templates/customer/password-new.tpl
@@ -51,10 +51,10 @@
             sprintf=['%email%' => $customer_email|stripslashes]}
         </div>
 
-        <div class="container-fluid">
+        <div class="container-fluid field-password-policy">
           <div class="row form-group">
             <label class="form-control-label col-md-3 offset-md-2">{l s='New password' d='Shop.Forms.Labels'}</label>
-            <div class="col-md-4">
+            <div class="col-md-4 js-input-column">
               <input class="form-control" type="password" data-validate="isPasswd" name="passwd" value="">
             </div>
           </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | if you try to do the password reset steps, you will get the reset page where to set a new password two times
from this page is not present the new password verification, in fact it is possible to set weak password
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#35410](https://github.com/PrestaShop/PrestaShop/issues/35410)
| Sponsor company   | Codencode
| How to test?      |  1. go at login<br> 2. push on the link "I don't remember the password" <br> 3. set an email to get the reset link <br> 4. push on the reset link<br> 5 set a new password, but weak like "casetta" <br> 6. Password verification will not appear
