### PR TITLE
Fix order return checkbox selector

### DIFF
--- a/_dev/js/customer.js
+++ b/_dev/js/customer.js
@@ -26,11 +26,8 @@ import $ from 'jquery';
 import prestashop from 'prestashop';
 
 function initRmaItemSelector() {
-  $(`${prestashop.themeSelectors.order.returnForm} table thead input[type=checkbox]`).on('click', function () {
-    const checked = $(this).prop('checked');
-    $(`${prestashop.themeSelectors.order.returnForm} table tbody input[type=checkbox]`).each((_, checkbox) => {
-      $(checkbox).prop('checked', checked);
-    });
+  $(prestashop.themeSelectors.order.returnFormCheckAll).on('click', function () {
+    $(prestashop.themeSelectors.order.returnFormCheckItem).prop('checked', this.checked);
   });
 }
 
@@ -40,4 +37,4 @@ function setupCustomerScripts() {
   }
 }
 
-$(document).ready(setupCustomerScripts);
+$(setupCustomerScripts);

--- a/_dev/js/selectors.js
+++ b/_dev/js/selectors.js
@@ -68,7 +68,8 @@ prestashop.themeSelectors = {
     searchLink: '.js-search-link',
   },
   order: {
-    returnForm: '#order-return-form, .js-order-return-form',
+    returnFormCheckItem: '.js-order-return-check-item',
+    returnFormCheckAll: '.js-order-return-check-all',
   },
   arrowDown: '.arrow-down, .js-arrow-down',
   arrowUp: '.arrow-up, .js-arrow-up',

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -29,7 +29,9 @@
       <table id="order-products" class="table table-bordered return">
         <thead class="thead-default">
           <tr>
-            <th class="head-checkbox"><input type="checkbox"/></th>
+            <th class="head-checkbox">
+              <input type="checkbox" class="js-order-return-check-all">
+            </th>
             <th>{l s='Product' d='Shop.Theme.Catalog'}</th>
             <th>{l s='Quantity' d='Shop.Theme.Catalog'}</th>
             <th>{l s='Returned' d='Shop.Theme.Customeraccount'}</th>
@@ -42,7 +44,13 @@
             <td>
               {if !$product.is_virtual}
                 <span id="_desktop_product_line_{$product.id_order_detail}">
-                  <input type="checkbox" id="cb_{$product.id_order_detail}" name="ids_order_detail[{$product.id_order_detail}]" value="{$product.id_order_detail}">
+                  <input
+                    id="cb_{$product.id_order_detail}"
+                    class="js-order-return-check-item"
+                    name="ids_order_detail[{$product.id_order_detail}]"
+                    type="checkbox"
+                    value="{$product.id_order_detail}"
+                  >
                 </span>
               {/if}
             </td>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | https://github.com/PrestaShop/classic-theme/commit/a9c26cec9d1733dd4ed99fbd6cabf7fe963f2afe added `.js-` selectors in few places.<br>The one for order returns got messed up. It's supposed to be:<br>`#order-return-form table thead input[type=checkbox], .js-order-return-form table thead input[type=checkbox]`<br>`#order-return-form table tbody input[type=checkbox], .js-order-return-form table tbody input[type=checkbox]`<br>but instead it became:<br>`#order-return-form, .js-order-return-form table thead input[type=checkbox]`<br>`#order-return-form, .js-order-return-form table tbody input[type=checkbox]`. <br>This pr simplifies the selectors and the function to check all products for return.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | 1. Have an order with several products in your customer account<br>2. Start a return process and see if you can check all products at once from the table header
