### PR TITLE
Fix minimal quantity reset

### DIFF
--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -131,7 +131,10 @@ $(document).ready(() => {
     $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
 
     $quantityInput.on('focusout', () => {
-      if ($quantityInput.val() === '' || parseInt($quantityInput.val(), 10) < parseInt($quantityInput.attr('min'), 10)) {
+      if (
+        $quantityInput.val() === '' 
+        || parseInt($quantityInput.val(), 10) < parseInt($quantityInput.attr('min'), 10)
+      ) {
         $quantityInput.val($quantityInput.attr('min'));
         $quantityInput.trigger('change');
       }

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -131,7 +131,7 @@ $(document).ready(() => {
     $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
 
     $quantityInput.on('focusout', () => {
-      if ($quantityInput.val() === '' || $quantityInput.val() < $quantityInput.attr('min')) {
+      if ($quantityInput.val() === '' || parseInt($quantityInput.val()) < parseInt($quantityInput.attr('min'))) {
         $quantityInput.val($quantityInput.attr('min'));
         $quantityInput.trigger('change');
       }

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -131,7 +131,7 @@ $(document).ready(() => {
     $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
 
     $quantityInput.on('focusout', () => {
-      if ($quantityInput.val() === '' || parseInt($quantityInput.val()) < parseInt($quantityInput.attr('min'))) {
+      if ($quantityInput.val() === '' || parseInt($quantityInput.val(), 10) < parseInt($quantityInput.attr('min'), 10)) {
         $quantityInput.val($quantityInput.attr('min'));
         $quantityInput.trigger('change');
       }

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -132,7 +132,7 @@ $(document).ready(() => {
 
     $quantityInput.on('focusout', () => {
       if (
-        $quantityInput.val() === '' 
+        $quantityInput.val() === ''
         || parseInt($quantityInput.val(), 10) < parseInt($quantityInput.attr('min'), 10)
       ) {
         $quantityInput.val($quantityInput.attr('min'));


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description      | Fixes an issue when a product has a minimum quantity by sale, and user enter a value greater than the minimal with 2 or 3 digits in input field, and click outside, the value comes back to minimal
| Category | FO
| Type             | bug fix
| BC breaks        |  no
| Deprecations    | no
| Fixed ticket     | Fixes #36245, Fixes #28531
| Sponsor company   | @ComonSoft
| How to test      | 1. Go to back office, create a product with a minimal quantity for sale by 5 (sample, works with any value) less than 10
|  | 2. Go to frontend product page
|  | 3. In the quantity field, enter quantity greater than 10 by keyboard
|  | 4. Click outside the input (any where except +- arrows)
|  | 5. The quantity in the field goes back to 5.

