### PR TITLE
Format availability for the new style

### DIFF
--- a/_dev/css/components/products.scss
+++ b/_dev/css/components/products.scss
@@ -631,17 +631,10 @@
   }
 
   /* Reset some of the general styles on alert warning */
-  .alert-warning {
-    color: #664d03;
-    background-color: #fff3cd;
-    border-color: #ffecb5;
-  }
-
   .alert-warning .material-icons {
     padding-top: 0;
     margin-right: 0;
     font-size: 24px;
-    color: #664d03;
   }
 }
 

--- a/_dev/css/components/products.scss
+++ b/_dev/css/components/products.scss
@@ -621,20 +621,27 @@
   margin-top: 0.625rem;
   font-weight: 700;
 
-  .material-icons {
-    line-height: inherit;
+  .alert {
+    font-size: 1rem;
   }
 
-  .product-available {
-    color: $brand-success;
+  .alert-content-wrapper {
+    display: flex;
+    gap: 0.75rem;
   }
 
-  .product-unavailable {
-    color: $brand-warning;
+  /* Reset some of the general styles on alert warning */
+  .alert-warning {
+    color: #664d03;
+    background-color: #fff3cd;
+    border-color: #ffecb5;
   }
 
-  .product-last-items {
-    color: $brand-warning;
+  .alert-warning .material-icons {
+    padding-top: 0;
+    margin-right: 0;
+    font-size: 24px;
+    color: #664d03;
   }
 }
 

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -66,18 +66,35 @@
     {/block}
 
     {block name='product_availability'}
-      <span id="product-availability" class="js-product-availability">
+      <div id="product-availability" class="product-availability js-product-availability">
         {if $product.show_availability && $product.availability_message}
-          {if $product.availability == 'available'}
-            <i class="material-icons rtl-no-flip product-available">&#xE5CA;</i>
-          {elseif $product.availability == 'last_remaining_items'}
-            <i class="material-icons product-last-items">&#xE002;</i>
+
+          {** First, we prepare the icons and colors we want to use *}
+          {if $product.availability == 'in_stock'}
+            {assign 'availability_icon' 'E5CA'}
+            {assign 'availability_color' 'success'}
+          {elseif $product.availability == 'available' || $product.availability == 'last_remaining_items'}
+            {assign 'availability_icon' 'E002'}
+            {assign 'availability_color' 'warning'}
           {else}
-            <i class="material-icons product-unavailable">&#xE14B;</i>
+            {assign 'availability_icon' 'E14B'}
+            {assign 'availability_color' 'danger'}
           {/if}
-          {$product.availability_message}
+
+          {** And render the availability message with icon *}
+          <div class="alert alert-{$availability_color}" role="alert">
+            <div class="alert-content-wrapper">
+              <div><i class="material-icons rtl-no-flip">&#x{$availability_icon};</i></div>
+              <div>
+                <div>{$product.availability_message}</div>
+                {if !empty($product.availability_submessage)}
+                  <div><small>{$product.availability_submessage}</small></div>
+                {/if}
+              </div>
+            </div>
+          </div>
         {/if}
-      </span>
+      </div>
     {/block}
 
     {block name='product_minimal_quantity'}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adapts the template to display availability in a new way. Simmilar to https://github.com/PrestaShop/hummingbird/pull/658. I had to style alert warning specifically for this purpose, because it's hacked up higher in the CSS and I did not want to rewrite X other things on a dead theme. Now it looks OK.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | 
| How to test?      | 

### Related core PRs
- https://github.com/PrestaShop/PrestaShop/pull/37018 Moves "Available with different options" to a new array key.
- https://github.com/PrestaShop/PrestaShop/pull/37013 Allows to distinguish between in stock and on backorder, so we can display it in green.

### How it looks
In stock
![Snímek obrazovky 2024-12-05 160232](https://github.com/user-attachments/assets/03329ad5-6d94-43c0-a177-d810f33156a0)

Available on backorder
![Snímek obrazovky 2024-12-06 130147](https://github.com/user-attachments/assets/4afa09b8-02ad-4c43-b2ab-ef4fef4cf048)

Not available (+ a new availability submessage)
![Snímek obrazovky 2024-12-05 160147](https://github.com/user-attachments/assets/0d95c136-d5de-477e-8506-90abf976da93)

Disabled (and product displayed)
![Snímek obrazovky 2024-12-05 160314](https://github.com/user-attachments/assets/f27d041d-36ba-4eba-9768-c5a986b701b4)
