### PR TITLE
Removing backslashes in meta elements

### DIFF
--- a/templates/_partials/head.tpl
+++ b/templates/_partials/head.tpl
@@ -58,11 +58,11 @@
   {/block}
 
   {block name='head_open_graph'}
-    <meta property="og:title" content="{$page.meta.title}" />
-    <meta property="og:description" content="{$page.meta.description}" />
-    <meta property="og:url" content="{$urls.current_url}" />
-    <meta property="og:site_name" content="{$shop.name}" />
-    {if !isset($product) && $page.page_name != 'product'}<meta property="og:type" content="website" />{/if}
+    <meta property="og:title" content="{$page.meta.title}">
+    <meta property="og:description" content="{$page.meta.description}">
+    <meta property="og:url" content="{$urls.current_url}">
+    <meta property="og:site_name" content="{$shop.name}">
+    {if !isset($product) && $page.page_name != 'product'}<meta property="og:type" content="website">{/if}
   {/block}  
 {/block}
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Removing backslashes in meta elements so that the final page is valid (without warnings) according to the HTML specification.
| Type?             | improvement 
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     |  no
| Sponsor company   | no
| How to test?      | Test by https://validator.w3.org/, warnings regarding meta elements will disappear. 

Some meta elements are already without the backslash but some with, so let it be completely nice in this file.