### PR TITLE
fix(Tether): Load Tether to allow pop overs/hints

### DIFF
--- a/_dev/webpack.config.js
+++ b/_dev/webpack.config.js
@@ -24,10 +24,12 @@
  */
 
 const path = require('path');
+
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const CssoWebpackPlugin = require('csso-webpack-plugin').default;
 const LicensePlugin = require('webpack-license-plugin');
+const webpack = require('webpack');
 
 const config = {
   mode: process.env.NODE_ENV || 'development',
@@ -86,6 +88,9 @@ const config = {
         'bootstrap-touchspin@3.1.1': 'Apache-2.0',
       },
       replenishDefaultLicenseTexts: true,
+    }),
+    new webpack.ProvidePlugin({
+      Tether: 'tether',
     }),
   ],
 };

--- a/_dev/webpack.config.js
+++ b/_dev/webpack.config.js
@@ -24,7 +24,6 @@
  */
 
 const path = require('path');
-
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const CssoWebpackPlugin = require('csso-webpack-plugin').default;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Added webpack.ProvidePlugin({}) to give visibility to Tether. https://stackoverflow.com/a/42227783
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#39088](https://github.com/PrestaShop/PrestaShop/issues/39088)
| Sponsor company   | 
| How to test?      | Go to registration form and input a password, password hint must appear and console error `Uncaught (in promise) TypeError: Tether is not a constructor` disappears.

Wanted to replace `import 'expose-loader?exposes=Tether!tether';` but then got other issues, so exposing in this way works. 