### PR TITLE
feature: show carrier name associated to products in order history

### DIFF
--- a/templates/customer/_partials/order-carrier.tpl
+++ b/templates/customer/_partials/order-carrier.tpl
@@ -1,0 +1,47 @@
+<div class="box">
+  <table class="table table-striped table-bordered hidden-sm-down">
+    <thead class="thead-default">
+      <tr>
+        <th>{l s='Date' d='Shop.Theme.Global'}</th>
+        <th>{l s='Carrier' d='Shop.Theme.Checkout'}</th>
+        <th>{l s='Weight' d='Shop.Theme.Checkout'}</th>
+        <th>{l s='Shipping cost' d='Shop.Theme.Checkout'}</th>
+        <th>{l s='Tracking number' d='Shop.Theme.Checkout'}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach from=$order.shipping item=line}
+        <tr>
+          <td>{$line.shipping_date}</td>
+          <td>{$line.carrier_name}</td>
+          <td>{$line.shipping_weight}</td>
+          <td>{$line.shipping_cost}</td>
+          <td>{$line.tracking nofilter}</td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <div class="hidden-md-up shipping-lines">
+   {foreach from=$order.shipping item=line}
+      <div class="shipping-line">
+        <ul>
+          <li>
+            <strong>{l s='Date' d='Shop.Theme.Global'}</strong> {$line.shipping_date}
+          </li>
+          <li>
+            <strong>{l s='Carrier' d='Shop.Theme.Checkout'}</strong> {$line.carrier_name}
+          </li>
+          <li>
+            <strong>{l s='Weight' d='Shop.Theme.Checkout'}</strong> {$line.shipping_weight}
+          </li>
+          <li>
+            <strong>{l s='Shipping cost' d='Shop.Theme.Checkout'}</strong> {$line.shipping_cost}
+          </li>
+          <li>
+            <strong>{l s='Tracking number' d='Shop.Theme.Checkout'}</strong> {$line.tracking nofilter}
+          </li>
+        </ul>
+      </div>
+    {/foreach}
+  </div>
+</div>

--- a/templates/customer/_partials/order-detail-no-return-multishipment.tpl
+++ b/templates/customer/_partials/order-detail-no-return-multishipment.tpl
@@ -1,0 +1,114 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+{block name='order_products_table'}
+  <div class="box hidden-sm-down">
+    <table id="order-products" class="table table-bordered">
+      <thead class="thead-default">
+        <tr>
+          <th>{l s='Product' d='Shop.Theme.Catalog'}</th>
+          <th>{l s='Quantity' d='Shop.Theme.Catalog'}</th>
+          <th>{l s='Unit price' d='Shop.Theme.Catalog'}</th>
+          <th>{l s='Total price' d='Shop.Theme.Catalog'}</th>
+        </tr>
+      </thead>
+      {foreach $order->order_shipments['virtual_products'] item=product}
+        {include file='./order-detail-product-line-no-return.tpl' product=$product}
+      {/foreach}
+      {foreach $order->order_shipments['physical_products'] item=shipment}
+        {foreach from=$shipment['products'] item=product}
+          {include file='./order-detail-product-line-no-return.tpl' product=$product carrier_name=$shipment['carrier']['name']}
+        {/foreach}
+      {/foreach}
+      <tfoot>
+        {foreach $order.subtotals as $line}
+          {if $line.value}
+            <tr class="text-xs-right line-{$line.type}">
+              <td colspan="3">{$line.label}</td>
+              <td>{$line.value}</td>
+            </tr>
+          {/if}
+        {/foreach}
+        <tr class="text-xs-right line-{$order.totals.total.type}">
+          <td colspan="3">{$order.totals.total.label}</td>
+          <td>{$order.totals.total.value}</td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+
+  <div class="order-items hidden-md-up box">
+    {foreach from=$order.products item=product}
+      <div class="order-item">
+        <div class="row">
+          <div class="col-sm-5 desc">
+            <div class="name">{$product.name}</div>
+            {if $product.product_reference}
+              <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
+            {/if}
+            {if isset($product.download_link)}
+              <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+            {/if}
+            {if $product.customizations}
+              {foreach $product.customizations as $customization}
+                <div class="customization">
+                  <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+                </div>
+                <div id="_mobile_product_customization_modal_wrapper_{$customization.id_customization}">
+                </div>
+              {/foreach}
+            {/if}
+          </div>
+          <div class="col-sm-7 qty">
+            <div class="row">
+              <div class="col-xs-4 text-sm-left text-xs-left">
+                {$product.price}
+              </div>
+              <div class="col-xs-4">
+                {$product.quantity}
+              </div>
+              <div class="col-xs-4 text-xs-right">
+                {$product.total}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    {/foreach}
+  </div>
+  <div class="order-totals hidden-md-up box">
+    {foreach $order.subtotals as $line}
+      {if $line.value}
+        <div class="order-total row">
+          <div class="col-xs-8"><strong>{$line.label}</strong></div>
+          <div class="col-xs-4 text-xs-right">{$line.value}</div>
+        </div>
+      {/if}
+    {/foreach}
+    <div class="order-total row">
+      <div class="col-xs-8"><strong>{$order.totals.total.label}</strong></div>
+      <div class="col-xs-4 text-xs-right">{$order.totals.total.value}</div>
+    </div>
+  </div>
+{/block}

--- a/templates/customer/_partials/order-detail-no-return-multishipment.tpl
+++ b/templates/customer/_partials/order-detail-no-return-multishipment.tpl
@@ -33,13 +33,13 @@
           <th>{l s='Total price' d='Shop.Theme.Catalog'}</th>
         </tr>
       </thead>
-      {foreach $order->order_shipments['virtual_products'] item=product}
-        {include file='./order-detail-product-line-no-return.tpl' product=$product}
-      {/foreach}
       {foreach $order->order_shipments['physical_products'] item=shipment}
         {foreach from=$shipment['products'] item=product}
           {include file='./order-detail-product-line-no-return.tpl' product=$product carrier_name=$shipment['carrier']['name']}
         {/foreach}
+      {/foreach}
+      {foreach $order->order_shipments['virtual_products'] item=product}
+        {include file='./order-detail-product-line-no-return.tpl' product=$product}
       {/foreach}
       <tfoot>
         {foreach $order.subtotals as $line}
@@ -59,42 +59,13 @@
   </div>
 
   <div class="order-items hidden-md-up box">
-    {foreach from=$order.products item=product}
-      <div class="order-item">
-        <div class="row">
-          <div class="col-sm-5 desc">
-            <div class="name">{$product.name}</div>
-            {if $product.product_reference}
-              <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
-            {/if}
-            {if isset($product.download_link)}
-              <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
-            {/if}
-            {if $product.customizations}
-              {foreach $product.customizations as $customization}
-                <div class="customization">
-                  <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
-                </div>
-                <div id="_mobile_product_customization_modal_wrapper_{$customization.id_customization}">
-                </div>
-              {/foreach}
-            {/if}
-          </div>
-          <div class="col-sm-7 qty">
-            <div class="row">
-              <div class="col-xs-4 text-sm-left text-xs-left">
-                {$product.price}
-              </div>
-              <div class="col-xs-4">
-                {$product.quantity}
-              </div>
-              <div class="col-xs-4 text-xs-right">
-                {$product.total}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+    {foreach $order->order_shipments['physical_products'] item=shipment}
+      {foreach from=$shipment['products'] item=product}
+        {include file='./order-detail-product-line-no-return-mobile.tpl' product=$product carrier_name=$shipment['carrier']['name']}
+      {/foreach}
+    {/foreach}
+    {foreach $order->order_shipments['virtual_products'] item=product}
+      {include file='./order-detail-product-line-no-return-mobile.tpl' product=$product}
     {/foreach}
   </div>
   <div class="order-totals hidden-md-up box">

--- a/templates/customer/_partials/order-detail-no-return.tpl
+++ b/templates/customer/_partials/order-detail-no-return.tpl
@@ -42,7 +42,7 @@
               </a>
             </strong><br/>
             {if $product.product_reference}
-              {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
+              {l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}<br/>
             {/if}
             {if isset($product.download_link)}
               <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
@@ -123,7 +123,7 @@
           <div class="col-sm-5 desc">
             <div class="name">{$product.name}</div>
             {if $product.product_reference}
-              <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
+              <div class="ref">{l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}</div>
             {/if}
             {if isset($product.download_link)}
               <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>

--- a/templates/customer/_partials/order-detail-product-line-no-return-mobile.tpl
+++ b/templates/customer/_partials/order-detail-product-line-no-return-mobile.tpl
@@ -1,0 +1,43 @@
+{block name='order_products_table_line_no_return_mobile'}
+  <div class="order-item">
+    <div class="row">
+      <div class="col-sm-5 desc">
+        <div class="name">{$product.name}</div>
+        {if $product.product_reference}
+          <div class="ref">{l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}</div>
+        {/if}
+        {if isset($carrier_name)}
+          <div class="carrier">{l s='Carrier: %carrier_name%' sprintf=['%carrier_name%' => $carrier_name] d='Shop.Theme.Catalog'}</div>
+        {/if}
+        {if isset($product.download_link)}
+          <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+        {/if}
+        {if $product.is_virtual}
+          {l s='Virtual products can\'t be returned.' d='Shop.Theme.Catalog'}</br>
+        {/if}
+        {if $product.customizations}
+          {foreach $product.customizations as $customization}
+            <div class="customization">
+              <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+            </div>
+            <div id="_mobile_product_customization_modal_wrapper_{$customization.id_customization}">
+            </div>
+          {/foreach}
+        {/if}
+      </div>
+      <div class="col-sm-7 qty">
+        <div class="row">
+          <div class="col-xs-4 text-sm-left text-xs-left">
+            {$product.price}
+          </div>
+          <div class="col-xs-4">
+            {$product.quantity}
+          </div>
+          <div class="col-xs-4 text-xs-right">
+            {$product.total}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{/block}

--- a/templates/customer/_partials/order-detail-product-line-no-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-no-return.tpl
@@ -1,69 +1,69 @@
 {block name='order_products_table_line_no_return'}
-<tr>
-  <td>
-    <strong>
-      <a href="{$urls.pages.product}&id_product={$product.id_product}">
-        {$product.name}
-      </a>
-    </strong><br/>
-    {if $product.product_reference}
-      {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
-    {/if}
-    {if isset($carrier_name)}
-      {l s='Carrier' d='Shop.Theme.Catalog'}: {$carrier_name}<br/>
-    {/if}
-    {if isset($product.download_link)}
-      <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
-    {/if}
-    {if $product.is_virtual}
-      {l s='Virtual products can\'t be returned.' d='Shop.Theme.Customeraccount'}</br>
-    {/if}
-    {if $product.customizations}
-      {foreach from=$product.customizations item="customization"}
-        <div class="customization">
-          <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
-        </div>
-        <div id="_desktop_product_customization_modal_wrapper_{$customization.id_customization}">
-          <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}">
-                    <span aria-hidden="true">&times;</span>
-                  </button>
-                  <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
-                </div>
-                <div class="modal-body">
-                  {foreach from=$customization.fields item="field"}
-                    <div class="product-customization-line row">
-                      <div class="col-sm-3 col-xs-4 label">
-                        {$field.label}
-                      </div>
-                      <div class="col-sm-9 col-xs-8 value">
-                        {if $field.type == 'text'}
-                          {if (int)$field.id_module}
-                            {$field.text nofilter}
-                          {else}
-                            {$field.text}
+  <tr>
+    <td>
+      <strong>
+        <a href="{$urls.pages.product}&id_product={$product.id_product}">
+          {$product.name}
+        </a>
+      </strong><br/>
+      {if $product.product_reference}
+        {l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}<br/>
+      {/if}
+      {if isset($carrier_name)}
+        {l s='Carrier: %carrier_name%' sprintf=['%carrier_name%' => $carrier_name] d='Shop.Theme.Catalog'}<br/>
+      {/if}
+      {if isset($product.download_link)}
+        <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+      {/if}
+      {if $product.is_virtual}
+        {l s='Virtual products can\'t be returned.' d='Shop.Theme.Customeraccount'}</br>
+      {/if}
+      {if $product.customizations}
+        {foreach from=$product.customizations item="customization"}
+          <div class="customization">
+            <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+          </div>
+          <div id="_desktop_product_customization_modal_wrapper_{$customization.id_customization}">
+            <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                    <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
+                  </div>
+                  <div class="modal-body">
+                    {foreach from=$customization.fields item="field"}
+                      <div class="product-customization-line row">
+                        <div class="col-sm-3 col-xs-4 label">
+                          {$field.label}
+                        </div>
+                        <div class="col-sm-9 col-xs-8 value">
+                          {if $field.type == 'text'}
+                            {if (int)$field.id_module}
+                              {$field.text nofilter}
+                            {else}
+                              {$field.text}
+                            {/if}
+                          {elseif $field.type == 'image'}
+                            <img src="{$field.image.small.url}" loading="lazy">
                           {/if}
-                        {elseif $field.type == 'image'}
-                          <img src="{$field.image.small.url}" loading="lazy">
-                        {/if}
+                        </div>
                       </div>
-                    </div>
-                  {/foreach}
+                    {/foreach}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      {/foreach}
-    {/if}
-  </td>
-  <td>
-    {$product.quantity}
-  </td>
-  <td class="text-xs-right">{$product.price}</td>
-  <td class="text-xs-right">{$product.total}</td>
-</tr>
+        {/foreach}
+      {/if}
+    </td>
+    <td>
+      {$product.quantity}
+    </td>
+    <td class="text-xs-right">{$product.price}</td>
+    <td class="text-xs-right">{$product.total}</td>
+  </tr>
 {/block}

--- a/templates/customer/_partials/order-detail-product-line-no-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-no-return.tpl
@@ -1,0 +1,69 @@
+{block name='order_products_table_line_no_return'}
+<tr>
+  <td>
+    <strong>
+      <a href="{$urls.pages.product}&id_product={$product.id_product}">
+        {$product.name}
+      </a>
+    </strong><br/>
+    {if $product.product_reference}
+      {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
+    {/if}
+    {if isset($carrier_name)}
+      {l s='Carrier' d='Shop.Theme.Catalog'}: {$carrier_name}<br/>
+    {/if}
+    {if isset($product.download_link)}
+      <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+    {/if}
+    {if $product.is_virtual}
+      {l s='Virtual products can\'t be returned.' d='Shop.Theme.Customeraccount'}</br>
+    {/if}
+    {if $product.customizations}
+      {foreach from=$product.customizations item="customization"}
+        <div class="customization">
+          <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+        </div>
+        <div id="_desktop_product_customization_modal_wrapper_{$customization.id_customization}">
+          <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                  <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
+                </div>
+                <div class="modal-body">
+                  {foreach from=$customization.fields item="field"}
+                    <div class="product-customization-line row">
+                      <div class="col-sm-3 col-xs-4 label">
+                        {$field.label}
+                      </div>
+                      <div class="col-sm-9 col-xs-8 value">
+                        {if $field.type == 'text'}
+                          {if (int)$field.id_module}
+                            {$field.text nofilter}
+                          {else}
+                            {$field.text}
+                          {/if}
+                        {elseif $field.type == 'image'}
+                          <img src="{$field.image.small.url}" loading="lazy">
+                        {/if}
+                      </div>
+                    </div>
+                  {/foreach}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/foreach}
+    {/if}
+  </td>
+  <td>
+    {$product.quantity}
+  </td>
+  <td class="text-xs-right">{$product.price}</td>
+  <td class="text-xs-right">{$product.total}</td>
+</tr>
+{/block}

--- a/templates/customer/_partials/order-detail-product-line-return-mobile.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return-mobile.tpl
@@ -1,0 +1,56 @@
+{block name='order_products_table_line_return_mobile'}
+  <div class="order-item">
+    <div class="row">
+      <div class="checkbox">
+        {if !$product.customizations}
+          <span id="_mobile_product_line_{$product.id_order_detail}"></span>
+        {else}
+          {foreach $product.customizations  as $customization}
+            <span id="_mobile_product_line_{$product.id_order_detail}"></span>
+          {/foreach}
+        {/if}
+      </div>
+      <div class="content">
+        <div class="row">
+          <div class="col-sm-5 desc">
+            <div class="name">{$product.name}</div>
+            {if $product.product_reference}
+              <div class="ref">{l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}</div>
+            {/if}
+            {if isset($product.download_link)}
+              <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+            {/if}
+            {if $product.customizations}
+              {foreach $product.customizations as $customization}
+                <div class="customization">
+                  <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+                </div>
+                <div id="_mobile_product_customization_modal_wrapper_{$customization.id_customization}">
+                </div>
+              {/foreach}
+            {/if}
+          </div>
+          <div class="col-sm-7 qty">
+            <div class="row">
+              <div class="col-xs-4 text-sm-left text-xs-left">
+                {$product.price}
+              </div>
+              <div class="col-xs-4">
+                <div class="q">{l s='Quantity' d='Shop.Theme.Catalog'}: {$product.quantity}</div>
+                {if $product.quantity > $product.qty_returned}
+                  <div class="s" id="_mobile_return_qty_{$product.id_order_detail}"></div>
+                {/if}
+                {if $product.qty_returned > 0}
+                  <div>{l s='Returned' d='Shop.Theme.Customeraccount'}: {$product.qty_returned}</div>
+                {/if}
+              </div>
+              <div class="col-xs-4 text-xs-right">
+                {$product.total}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{/block}

--- a/templates/customer/_partials/order-detail-product-line-return-mobile.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return-mobile.tpl
@@ -5,7 +5,7 @@
         {if !$product.customizations}
           <span id="_mobile_product_line_{$product.id_order_detail}"></span>
         {else}
-          {foreach $product.customizations  as $customization}
+          {foreach $product.customizations as $customization}
             <span id="_mobile_product_line_{$product.id_order_detail}"></span>
           {/foreach}
         {/if}

--- a/templates/customer/_partials/order-detail-product-line-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return.tpl
@@ -1,0 +1,84 @@
+{block name='order_products_table_line_return'}
+<tr>
+  <td>
+    {if !$product.is_virtual}
+      <span id="_desktop_product_line_{$product.id_order_detail}">
+        <input type="checkbox" id="cb_{$product.id_order_detail}" name="ids_order_detail[{$product.id_order_detail}]" value="{$product.id_order_detail}">
+      </span>
+    {/if}
+  </td>
+  <td>
+    <strong>{$product.name}</strong><br/>
+    {if $product.product_reference}
+      {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
+    {/if}
+    {if isset($carrier_name)}
+      {l s='Carrier' d='Shop.Theme.Catalog'}: {$carrier_name}<br/>
+    {/if}
+    {if $product.is_virtual}
+      {l s='Virtual products can\'t be returned.' d='Shop.Theme.Customeraccount'}<br/>
+    {/if}
+    {if isset($product.download_link)}
+      <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+    {/if}
+    {if $product.customizations}
+      {foreach from=$product.customizations item="customization"}
+        <div class="customization">
+          <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+        </div>
+        <div id="_desktop_product_customization_modal_wrapper_{$customization.id_customization}">
+          <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                  <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
+                </div>
+                <div class="modal-body">
+                  {foreach from=$customization.fields item="field"}
+                    <div class="product-customization-line row">
+                      <div class="col-sm-3 col-xs-4 label">
+                        {$field.label}
+                      </div>
+                      <div class="col-sm-9 col-xs-8 value">
+                        {if $field.type == 'text'}
+                          {if (int)$field.id_module}
+                            {$field.text nofilter}
+                          {else}
+                            {$field.text}
+                          {/if}
+                        {elseif $field.type == 'image'}
+                          <img src="{$field.image.small.url}" loading="lazy">
+                        {/if}
+                      </div>
+                    </div>
+                  {/foreach}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/foreach}
+    {/if}
+  </td>
+  <td class="qty">
+    <div class="current">
+      {$product.quantity}
+    </div>
+    {if $product.quantity > $product.qty_returned && !$product.is_virtual}
+      <div class="select" id="_desktop_return_qty_{$product.id_order_detail}">
+        <select name="order_qte_input[{$product.id_order_detail}]" class="form-control form-control-select">
+          {section name=quantity start=1 loop=$product.quantity+1-$product.qty_returned}
+            <option value="{$smarty.section.quantity.index}">{$smarty.section.quantity.index}</option>
+          {/section}
+        </select>
+      </div>
+      {/if}
+  </td>
+  <td class="text-xs-right">{if !$product.is_virtual}{$product.qty_returned}{/if}</td>
+  <td class="text-xs-right">{$product.price}</td>
+  <td class="text-xs-right">{$product.total}</td>
+</tr>
+{/block}

--- a/templates/customer/_partials/order-detail-product-line-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return.tpl
@@ -75,7 +75,7 @@
             {/section}
           </select>
         </div>
-        {/if}
+      {/if}
     </td>
     <td class="text-xs-right">{if !$product.is_virtual}{$product.qty_returned}{/if}</td>
     <td class="text-xs-right">{$product.price}</td>

--- a/templates/customer/_partials/order-detail-product-line-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return.tpl
@@ -1,84 +1,84 @@
 {block name='order_products_table_line_return'}
-<tr>
-  <td>
-    {if !$product.is_virtual}
-      <span id="_desktop_product_line_{$product.id_order_detail}">
-        <input type="checkbox" id="cb_{$product.id_order_detail}" name="ids_order_detail[{$product.id_order_detail}]" value="{$product.id_order_detail}">
-      </span>
-    {/if}
-  </td>
-  <td>
-    <strong>{$product.name}</strong><br/>
-    {if $product.product_reference}
-      {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
-    {/if}
-    {if isset($carrier_name)}
-      {l s='Carrier' d='Shop.Theme.Catalog'}: {$carrier_name}<br/>
-    {/if}
-    {if $product.is_virtual}
-      {l s='Virtual products can\'t be returned.' d='Shop.Theme.Customeraccount'}<br/>
-    {/if}
-    {if isset($product.download_link)}
-      <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
-    {/if}
-    {if $product.customizations}
-      {foreach from=$product.customizations item="customization"}
-        <div class="customization">
-          <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
-        </div>
-        <div id="_desktop_product_customization_modal_wrapper_{$customization.id_customization}">
-          <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}">
-                    <span aria-hidden="true">&times;</span>
-                  </button>
-                  <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
-                </div>
-                <div class="modal-body">
-                  {foreach from=$customization.fields item="field"}
-                    <div class="product-customization-line row">
-                      <div class="col-sm-3 col-xs-4 label">
-                        {$field.label}
-                      </div>
-                      <div class="col-sm-9 col-xs-8 value">
-                        {if $field.type == 'text'}
-                          {if (int)$field.id_module}
-                            {$field.text nofilter}
-                          {else}
-                            {$field.text}
+  <tr>
+    <td>
+      {if !$product.is_virtual}
+        <span id="_desktop_product_line_{$product.id_order_detail}">
+          <input type="checkbox" id="cb_{$product.id_order_detail}" name="ids_order_detail[{$product.id_order_detail}]" value="{$product.id_order_detail}">
+        </span>
+      {/if}
+    </td>
+    <td>
+      <strong>{$product.name}</strong><br/>
+      {if $product.product_reference}
+        {l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}<br/>
+      {/if}
+      {if isset($carrier_name)}
+        {l s='Carrier: %carrier_name%' sprintf=['%carrier_name%' => $carrier_name] d='Shop.Theme.Catalog'}<br/>
+      {/if}
+      {if $product.is_virtual}
+        {l s='Virtual products can\'t be returned.' d='Shop.Theme.Catalog'}<br/>
+      {/if}
+      {if isset($product.download_link)}
+        <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+      {/if}
+      {if $product.customizations}
+        {foreach from=$product.customizations item="customization"}
+          <div class="customization">
+            <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+          </div>
+          <div id="_desktop_product_customization_modal_wrapper_{$customization.id_customization}">
+            <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                    <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
+                  </div>
+                  <div class="modal-body">
+                    {foreach from=$customization.fields item="field"}
+                      <div class="product-customization-line row">
+                        <div class="col-sm-3 col-xs-4 label">
+                          {$field.label}
+                        </div>
+                        <div class="col-sm-9 col-xs-8 value">
+                          {if $field.type == 'text'}
+                            {if (int)$field.id_module}
+                              {$field.text nofilter}
+                            {else}
+                              {$field.text}
+                            {/if}
+                          {elseif $field.type == 'image'}
+                            <img src="{$field.image.small.url}" loading="lazy">
                           {/if}
-                        {elseif $field.type == 'image'}
-                          <img src="{$field.image.small.url}" loading="lazy">
-                        {/if}
+                        </div>
                       </div>
-                    </div>
-                  {/foreach}
+                    {/foreach}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      {/foreach}
-    {/if}
-  </td>
-  <td class="qty">
-    <div class="current">
-      {$product.quantity}
-    </div>
-    {if $product.quantity > $product.qty_returned && !$product.is_virtual}
-      <div class="select" id="_desktop_return_qty_{$product.id_order_detail}">
-        <select name="order_qte_input[{$product.id_order_detail}]" class="form-control form-control-select">
-          {section name=quantity start=1 loop=$product.quantity+1-$product.qty_returned}
-            <option value="{$smarty.section.quantity.index}">{$smarty.section.quantity.index}</option>
-          {/section}
-        </select>
-      </div>
+        {/foreach}
       {/if}
-  </td>
-  <td class="text-xs-right">{if !$product.is_virtual}{$product.qty_returned}{/if}</td>
-  <td class="text-xs-right">{$product.price}</td>
-  <td class="text-xs-right">{$product.total}</td>
-</tr>
+    </td>
+    <td class="qty">
+      <div class="current">
+        {$product.quantity}
+      </div>
+      {if $product.quantity > $product.qty_returned && !$product.is_virtual}
+        <div class="select" id="_desktop_return_qty_{$product.id_order_detail}">
+          <select name="order_qte_input[{$product.id_order_detail}]" class="form-control form-control-select">
+            {section name=quantity start=1 loop=$product.quantity+1-$product.qty_returned}
+              <option value="{$smarty.section.quantity.index}">{$smarty.section.quantity.index}</option>
+            {/section}
+          </select>
+        </div>
+        {/if}
+    </td>
+    <td class="text-xs-right">{if !$product.is_virtual}{$product.qty_returned}{/if}</td>
+    <td class="text-xs-right">{$product.price}</td>
+    <td class="text-xs-right">{$product.total}</td>
+  </tr>
 {/block}

--- a/templates/customer/_partials/order-detail-return-multishipment.tpl
+++ b/templates/customer/_partials/order-detail-return-multishipment.tpl
@@ -1,0 +1,157 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+{block name='order_products_table'}
+  <form id="order-return-form" class="js-order-return-form" action="{$urls.pages.order_follow}" method="post">
+
+    <div class="box hidden-sm-down">
+      <table id="order-products" class="table table-bordered return">
+        <thead class="thead-default">
+          <tr>
+            <th class="head-checkbox"><input type="checkbox"/></th>
+            <th>{l s='Product' d='Shop.Theme.Catalog'}</th>
+            <th>{l s='Quantity' d='Shop.Theme.Catalog'}</th>
+            <th>{l s='Returned' d='Shop.Theme.Customeraccount'}</th>
+            <th>{l s='Unit price' d='Shop.Theme.Catalog'}</th>
+            <th>{l s='Total price' d='Shop.Theme.Catalog'}</th>
+          </tr>
+        </thead>
+        {foreach $order->order_shipments['virtual_products'] item=product}
+          {include file='./order-detail-product-line-return.tpl' product=$product}
+        {/foreach}
+        {foreach $order->order_shipments['physical_products'] item=shipment}
+          {foreach from=$shipment['products'] item=product}
+            {include file='./order-detail-product-line-return.tpl' product=$product carrier_name=$shipment['carrier']['name']}
+          {/foreach}
+        {/foreach}
+        <tfoot>
+          {foreach $order.subtotals as $line}
+            {if $line.value}
+              <tr class="text-xs-right line-{$line.type}">
+                <td colspan="5">{$line.label}</td>
+                <td colspan="2">{$line.value}</td>
+              </tr>
+            {/if}
+          {/foreach}
+          <tr class="text-xs-right line-{$order.totals.total.type}">
+            <td colspan="5">{$order.totals.total.label}</td>
+            <td colspan="2">{$order.totals.total.value}</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+
+    <div class="order-items hidden-md-up box">
+      {foreach from=$order.products item=product}
+        <div class="order-item">
+          <div class="row">
+            <div class="checkbox">
+              {if !$product.customizations}
+                <span id="_mobile_product_line_{$product.id_order_detail}"></span>
+              {else}
+                {foreach $product.customizations  as $customization}
+                  <span id="_mobile_product_customization_line_{$product.id_order_detail}_{$customization.id_customization}"></span>
+                {/foreach}
+              {/if}
+            </div>
+            <div class="content">
+              <div class="row">
+                <div class="col-sm-5 desc">
+                  <div class="name">{$product.name}</div>
+                  {if $product.product_reference}
+                    <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
+                  {/if}
+                  {if isset($product.download_link)}
+                    <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
+                  {/if}
+                  {if $product.customizations}
+                    {foreach $product.customizations as $customization}
+                      <div class="customization">
+                        <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+                      </div>
+                      <div id="_mobile_product_customization_modal_wrapper_{$customization.id_customization}">
+                      </div>
+                    {/foreach}
+                  {/if}
+                </div>
+                <div class="col-sm-7 qty">
+                  <div class="row">
+                    <div class="col-xs-4 text-sm-left text-xs-left">
+                      {$product.price}
+                    </div>
+                    <div class="col-xs-4">
+                      <div class="q">{l s='Quantity' d='Shop.Theme.Catalog'}: {$product.quantity}</div>
+                      {if $product.quantity > $product.qty_returned}
+                        <div class="s" id="_mobile_return_qty_{$product.id_order_detail}"></div>
+                      {/if}
+                      {if $product.qty_returned > 0}
+                        <div>{l s='Returned' d='Shop.Theme.Customeraccount'}: {$product.qty_returned}</div>
+                      {/if}
+                    </div>
+                    <div class="col-xs-4 text-xs-right">
+                      {$product.total}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/foreach}
+    </div>
+    <div class="order-totals hidden-md-up box">
+      {foreach $order.subtotals as $line}
+        {if $line.value}
+          <div class="order-total row">
+            <div class="col-xs-8"><strong>{$line.label}</strong></div>
+            <div class="col-xs-4 text-xs-right">{$line.value}</div>
+          </div>
+        {/if}
+      {/foreach}
+      <div class="order-total row">
+        <div class="col-xs-8"><strong>{$order.totals.total.label}</strong></div>
+        <div class="col-xs-4 text-xs-right">{$order.totals.total.value}</div>
+      </div>
+    </div>
+
+    <div class="box">
+      <header>
+        <h3>{l s='Merchandise return' d='Shop.Theme.Customeraccount'}</h3>
+        <p>{l s='If you wish to return one or more products, please mark the corresponding boxes and provide an explanation for the return. When complete, click the button below.' d='Shop.Theme.Customeraccount'}</p>
+      </header>
+      <section class="form-fields">
+        <div class="form-group">
+          <textarea cols="67" rows="3" name="returnText" class="form-control"></textarea>
+        </div>
+      </section>
+      <footer class="form-footer">
+        <input type="hidden" name="id_order" value="{$order.details.id}">
+        <button class="form-control-submit btn btn-primary" type="submit" name="submitReturnMerchandise">
+          {l s='Request a return' d='Shop.Theme.Customeraccount'}
+        </button>
+      </footer>
+    </div>
+
+  </form>
+{/block}

--- a/templates/customer/_partials/order-detail-return-multishipment.tpl
+++ b/templates/customer/_partials/order-detail-return-multishipment.tpl
@@ -37,13 +37,13 @@
             <th>{l s='Total price' d='Shop.Theme.Catalog'}</th>
           </tr>
         </thead>
-        {foreach $order->order_shipments['virtual_products'] item=product}
-          {include file='./order-detail-product-line-return.tpl' product=$product}
-        {/foreach}
         {foreach $order->order_shipments['physical_products'] item=shipment}
           {foreach from=$shipment['products'] item=product}
             {include file='./order-detail-product-line-return.tpl' product=$product carrier_name=$shipment['carrier']['name']}
           {/foreach}
+        {/foreach}
+        {foreach $order->order_shipments['virtual_products'] item=product}
+          {include file='./order-detail-product-line-return.tpl' product=$product}
         {/foreach}
         <tfoot>
           {foreach $order.subtotals as $line}
@@ -63,61 +63,13 @@
     </div>
 
     <div class="order-items hidden-md-up box">
-      {foreach from=$order.products item=product}
-        <div class="order-item">
-          <div class="row">
-            <div class="checkbox">
-              {if !$product.customizations}
-                <span id="_mobile_product_line_{$product.id_order_detail}"></span>
-              {else}
-                {foreach $product.customizations  as $customization}
-                  <span id="_mobile_product_customization_line_{$product.id_order_detail}_{$customization.id_customization}"></span>
-                {/foreach}
-              {/if}
-            </div>
-            <div class="content">
-              <div class="row">
-                <div class="col-sm-5 desc">
-                  <div class="name">{$product.name}</div>
-                  {if $product.product_reference}
-                    <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
-                  {/if}
-                  {if isset($product.download_link)}
-                    <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>
-                  {/if}
-                  {if $product.customizations}
-                    {foreach $product.customizations as $customization}
-                      <div class="customization">
-                        <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
-                      </div>
-                      <div id="_mobile_product_customization_modal_wrapper_{$customization.id_customization}">
-                      </div>
-                    {/foreach}
-                  {/if}
-                </div>
-                <div class="col-sm-7 qty">
-                  <div class="row">
-                    <div class="col-xs-4 text-sm-left text-xs-left">
-                      {$product.price}
-                    </div>
-                    <div class="col-xs-4">
-                      <div class="q">{l s='Quantity' d='Shop.Theme.Catalog'}: {$product.quantity}</div>
-                      {if $product.quantity > $product.qty_returned}
-                        <div class="s" id="_mobile_return_qty_{$product.id_order_detail}"></div>
-                      {/if}
-                      {if $product.qty_returned > 0}
-                        <div>{l s='Returned' d='Shop.Theme.Customeraccount'}: {$product.qty_returned}</div>
-                      {/if}
-                    </div>
-                    <div class="col-xs-4 text-xs-right">
-                      {$product.total}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+      {foreach $order->order_shipments['physical_products'] item=shipment}
+        {foreach from=$shipment['products'] item=product}
+          {include file='./order-detail-product-line-return-mobile.tpl' product=$product carrier_name=$shipment['carrier']['name']}
+        {/foreach}
+      {/foreach}
+      {foreach $order->order_shipments['virtual_products'] item=product}
+        {include file='./order-detail-product-line-return-mobile.tpl' product=$product}
       {/foreach}
     </div>
     <div class="order-totals hidden-md-up box">

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -49,7 +49,7 @@
             <td>
               <strong>{$product.name}</strong><br/>
               {if $product.product_reference}
-                {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}<br/>
+                {l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}<br/>
               {/if}
               {if $product.is_virtual}
                 {l s='Virtual products can\'t be returned.' d='Shop.Theme.Customeraccount'}<br/>
@@ -153,7 +153,7 @@
                 <div class="col-sm-5 desc">
                   <div class="name">{$product.name}</div>
                   {if $product.product_reference}
-                    <div class="ref">{l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}</div>
+                    <div class="ref">{l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}</div>
                   {/if}
                   {if isset($product.download_link)}
                     <a href="{$product.download_link}">{l s='Download' d='Shop.Theme.Actions'}</a><br/>

--- a/templates/customer/_partials/order-shipments.tpl
+++ b/templates/customer/_partials/order-shipments.tpl
@@ -1,0 +1,62 @@
+<div class="box">
+  <table class="table table-striped table-bordered hidden-sm-down">
+    <thead class="thead-default">
+      <tr>
+        <th>{l s='Date' d='Shop.Theme.Global'}</th>
+        <th>{l s='Carrier' d='Shop.Theme.Checkout'}</th>
+        <th>{l s='Weight' d='Shop.Theme.Checkout'}</th>
+        <th>{l s='Shipping cost' d='Shop.Theme.Checkout'}</th>
+        <th>{l s='Tracking number' d='Shop.Theme.Checkout'}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {foreach from=$order.shipping item=line}
+        <tr>
+          <td>{$line.date_add}</td>
+          <td>{$line.carrier_name}</td>
+          <td>{$line.package_weight}</td>
+          <td>{$line.package_cost}</td>
+          <td>
+            {if $line.carrier_tracking_url}
+              <a href="{$line.carrier_tracking_url}" target="_blank">{$line.tracking_number}</a>
+            {elseif $line.tracking_number}
+              {$line.tracking_number}
+            {else}
+              -
+            {/if}
+          </td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
+  <div class="hidden-md-up shipping-lines">
+   {foreach from=$order.shipping item=line}
+      <div class="shipping-line">
+        <ul>
+          <li>
+            <strong>{l s='Date' d='Shop.Theme.Global'}</strong> {$line.date_add}
+          </li>
+          <li>
+            <strong>{l s='Carrier' d='Shop.Theme.Checkout'}</strong> {$line.carrier_name}
+          </li>
+          <li>
+            <strong>{l s='Weight' d='Shop.Theme.Checkout'}</strong> {$line.package_weight}
+          </li>
+          <li>
+            <strong>{l s='Shipping cost' d='Shop.Theme.Checkout'}</strong> {$line.package_cost}
+          </li>
+          <li>
+            <strong>{l s='Tracking number' d='Shop.Theme.Checkout'}</strong>
+            {if $line.carrier_tracking_url}
+              <a href="{$line.carrier_tracking_url}" target="_blank">{$line.tracking_number}</a>
+            {elseif $line.tracking_number}
+              {$line.tracking_number}
+            {else}
+              -
+            {/if}
+          </li>
+        </ul>
+      </div>
+    {/foreach}
+  </div>
+</div>

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -169,53 +169,11 @@
 
   {block name='order_carriers'}
     {if $order.shipping}
-      <div class="box">
-        <table class="table table-striped table-bordered hidden-sm-down">
-          <thead class="thead-default">
-            <tr>
-              <th>{l s='Date' d='Shop.Theme.Global'}</th>
-              <th>{l s='Carrier' d='Shop.Theme.Checkout'}</th>
-              <th>{l s='Weight' d='Shop.Theme.Checkout'}</th>
-              <th>{l s='Shipping cost' d='Shop.Theme.Checkout'}</th>
-              <th>{l s='Tracking number' d='Shop.Theme.Checkout'}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {foreach from=$order.shipping item=line}
-              <tr>
-                <td>{$line.shipping_date}</td>
-                <td>{$line.carrier_name}</td>
-                <td>{$line.shipping_weight}</td>
-                <td>{$line.shipping_cost}</td>
-                <td>{$line.tracking nofilter}</td>
-              </tr>
-            {/foreach}
-          </tbody>
-        </table>
-        <div class="hidden-md-up shipping-lines">
-          {foreach from=$order.shipping item=line}
-            <div class="shipping-line">
-              <ul>
-                <li>
-                  <strong>{l s='Date' d='Shop.Theme.Global'}</strong> {$line.shipping_date}
-                </li>
-                <li>
-                  <strong>{l s='Carrier' d='Shop.Theme.Checkout'}</strong> {$line.carrier_name}
-                </li>
-                <li>
-                  <strong>{l s='Weight' d='Shop.Theme.Checkout'}</strong> {$line.shipping_weight}
-                </li>
-                <li>
-                  <strong>{l s='Shipping cost' d='Shop.Theme.Checkout'}</strong> {$line.shipping_cost}
-                </li>
-                <li>
-                  <strong>{l s='Tracking number' d='Shop.Theme.Checkout'}</strong> {$line.tracking nofilter}
-                </li>
-              </ul>
-            </div>
-          {/foreach}
-        </div>
-      </div>
+      {if $is_multishipment_enabled}
+        {include file='customer/_partials/order-shipments.tpl'}
+      {else}
+        {include file='customer/_partials/order-carrier.tpl'}
+      {/if}
     {/if}
   {/block}
 

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -53,6 +53,11 @@
 
       <div class="box">
           <ul>
+            {if not $is_multishipment_enabled|default:false}
+              {if $order.carrier.name}
+                <li><strong>{l s='Carrier' d='Shop.Theme.Checkout'}</strong> {$order.carrier.name}</li>
+              {/if}
+            {/if}
             <li><strong>{l s='Payment method' d='Shop.Theme.Checkout'}</strong> {$order.details.payment}</li>
 
             {if $order.details.invoice_url}

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -148,13 +148,13 @@
 
   {block name='order_detail'}
     {if $order.details.is_returnable && !$orderIsVirtual}
-      {if $is_multishipment_enabled}
+      {if $is_multishipment_enabled|default:false}
         {include file='customer/_partials/order-detail-return-multishipment.tpl'}
       {else}
         {include file='customer/_partials/order-detail-return.tpl'}
       {/if}
     {else}
-      {if $is_multishipment_enabled}
+      {if $is_multishipment_enabled|default:false}
         {include file='customer/_partials/order-detail-no-return-multishipment.tpl'}
       {else}
         {include file='customer/_partials/order-detail-no-return.tpl'}

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -169,7 +169,7 @@
 
   {block name='order_carriers'}
     {if $order.shipping}
-      {if $is_multishipment_enabled}
+      {if $is_multishipment_enabled|default:false}
         {include file='customer/_partials/order-shipments.tpl'}
       {else}
         {include file='customer/_partials/order-carrier.tpl'}

--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -53,9 +53,6 @@
 
       <div class="box">
           <ul>
-            {if $order.carrier.name}
-              <li><strong>{l s='Carrier' d='Shop.Theme.Checkout'}</strong> {$order.carrier.name}</li>
-            {/if}
             <li><strong>{l s='Payment method' d='Shop.Theme.Checkout'}</strong> {$order.details.payment}</li>
 
             {if $order.details.invoice_url}
@@ -151,9 +148,17 @@
 
   {block name='order_detail'}
     {if $order.details.is_returnable && !$orderIsVirtual}
-      {include file='customer/_partials/order-detail-return.tpl'}
+      {if $is_multishipment_enabled}
+        {include file='customer/_partials/order-detail-return-multishipment.tpl'}
+      {else}
+        {include file='customer/_partials/order-detail-return.tpl'}
+      {/if}
     {else}
-      {include file='customer/_partials/order-detail-no-return.tpl'}
+      {if $is_multishipment_enabled}
+        {include file='customer/_partials/order-detail-no-return-multishipment.tpl'}
+      {else}
+        {include file='customer/_partials/order-detail-no-return.tpl'}
+      {/if}
     {/if}
   {/block}
 

--- a/templates/customer/order-return.tpl
+++ b/templates/customer/order-return.tpl
@@ -47,7 +47,7 @@
                 <strong>{$product.product_name}</strong>
                 {if $product.product_reference}
                   <br />
-                  {l s='Reference' d='Shop.Theme.Catalog'}: {$product.product_reference}
+                  {l s='Reference: %reference%' sprintf=['%reference%' => $product.product_reference] d='Shop.Theme.Catalog'}
                 {/if}
                 {if $product.customizations}
                   {foreach from=$product.customizations item="customization"}


### PR DESCRIPTION
This pull request update templates from the order history page in order to display the carrier name under each product line on the order summary. This is only visible when the `improved shipment` feature flag is enabled.

<img width="1905" height="1042" alt="image" src="https://github.com/user-attachments/assets/568e1385-610a-44e1-8fb2-c0c10ee39be0" />