### PR TITLE
Add captcha hook to contact form template for Cloudflare Turnstile (an others) integration

### DIFF
--- a/modules/contactform/views/templates/widget/contactform.tpl
+++ b/modules/contactform/views/templates/widget/contactform.tpl
@@ -128,6 +128,8 @@
         </style>
         <input type="text" name="url" value=""/>
         <input type="hidden" name="token" value="{$token}" />
+        {hook h='displayFormCaptcha'}
+        {/block}
         <input class="btn btn-primary" type="submit" name="submitMessage" value="{l s='Send' d='Shop.Theme.Actions'}">
       </footer>
     {/if}

--- a/templates/customer/_partials/login-form.tpl
+++ b/templates/customer/_partials/login-form.tpl
@@ -49,6 +49,8 @@
       <footer class="form-footer text-sm-center clearfix">
         <input type="hidden" name="submitLogin" value="1">
         {block name='form_buttons'}
+          {hook h='displayFormCaptcha'}
+          {/block}  
           <button id="submit-login" class="btn btn-primary" data-link-action="sign-in" type="submit" class="form-control-submit">
             {l s='Sign in' d='Shop.Theme.Actions'}
           </button>

--- a/templates/customer/password-email.tpl
+++ b/templates/customer/password-email.tpl
@@ -48,6 +48,9 @@
       <p class="send-renew-password-link">{l s='Please enter the email address you used to register. You will receive a temporary link to reset your password.' d='Shop.Theme.Customeraccount'}</p>
     </header>
 
+    {hook h='displayFormCaptcha'}
+    {/hook}
+
     <section class="form-fields">
       <div class="form-group center-email-fields">
         <label class="col-md-3 form-control-label required">{l s='Email address' d='Shop.Forms.Labels'}</label>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Actualmente, insertar Cloudflare Turnstile requiere modificar el archivo. Esto rompe compatibilidad al actualizar PrestaShop. Propongo un hook limpio para que los módulos puedan añadir su widget sin editar plantillas.

