### PR TITLE
Keep existing hooks in the theme config

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -1,6 +1,6 @@
 name: classic
 display_name: Classic
-version: 3.0.5
+version: 3.0.6
 author:
   name: "PrestaShop SA and Contributors"
   email: "contact@prestashop.com"

--- a/config/theme.yml
+++ b/config/theme.yml
@@ -58,25 +58,41 @@ global_settings:
     modules_to_hook:
       displayAfterBodyOpeningTag:
         - blockreassurance
+        # Keep existing hooks and append them after
+        - ~
       displayNavFullWidth:
         - blockreassurance
+        # Keep existing hooks and append them after
+        - ~
       displayAdminCustomers:
         - blockwishlist
+        # Keep existing hooks and append them after
+        - ~
       displayCustomerAccount:
         - blockwishlist
         - psgdpr
+        # Keep existing hooks and append them after
+        - ~
       displayMyAccountBlock:
         - blockwishlist
+        # Keep existing hooks and append them after
+        - ~
       displayNav1:
         - ps_contactinfo
+        # Keep existing hooks and append them after
+        - ~
       displayNav2:
         - ps_languageselector
         - ps_currencyselector
         - ps_customersignin
         - ps_shoppingcart
+        # Keep existing hooks and append them after
+        - ~
       displayTop:
         - ps_mainmenu
         - ps_searchbar
+        # Keep existing hooks and append them after
+        - ~
       displayHome:
         - ps_imageslider
         - ps_featuredproducts
@@ -85,41 +101,71 @@ global_settings:
         - ps_specials
         - ps_newproducts
         - ps_bestsellers
+        # Keep existing hooks and append them after
+        - ~
       displayFooterBefore:
         - ps_emailsubscription
         - ps_socialfollow
         - blockreassurance
+        # Keep existing hooks and append them after
+        - ~
       displayFooter:
         - ps_linklist
         - ps_customeraccountlinks
         - ps_contactinfo
         - blockwishlist
+        # Keep existing hooks and append them after
+        - ~
       displayFooterAfter:
         - blockreassurance
+        # Keep existing hooks and append them after
+        - ~
       displayFooterProduct:
         - productcomments
+        # Keep existing hooks and append them after
+        - ~
       displayLeftColumn:
         - ps_categorytree
         - ps_facetedsearch
+        # Keep existing hooks and append them after
+        - ~
       displayContactLeftColumn:
         - ps_contactinfo
+        # Keep existing hooks and append them after
+        - ~
       displayContactRightColumn:
         - ps_contactinfo
+        # Keep existing hooks and append them after
+        - ~
       displayContactContent:
         - contactform
+        # Keep existing hooks and append them after
+        - ~
       displaySearch:
         - ps_searchbar
+        # Keep existing hooks and append them after
+        - ~
       displayProductAdditionalInfo:
         - ps_sharebuttons
         - productcomments
+        # Keep existing hooks and append them after
+        - ~
       displayProductListReviews:
         - productcomments
+        # Keep existing hooks and append them after
+        - ~
       displayReassurance:
         - blockreassurance
+        # Keep existing hooks and append them after
+        - ~
       displayOrderConfirmation2:
         - ps_featuredproducts
+        # Keep existing hooks and append them after
+        - ~
       displayProductActions:
         - blockwishlist
+        # Keep existing hooks and append them after
+        - ~
 
   image_types:
     cart_default:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add placeholders in hook definitions to keep the existing hooks from other modules and avoid overriding them all
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | ~

This modification is done because we changed the order of steps during installation https://github.com/PrestaShop/PrestaShop/pull/40457 hich highlighted the fact that the config of the theme was not really used on fresh install To remain iso with the activated modules we update the theme config so that it is less strict and keep hooks from all installed modules

### How to test

1. You need to use the 9.1.x branch
2. Use the PR of this theme
3. Install the shop with all modules enabled, and select classic as the theme
4. Go to the list of products
5. Without this fix the Brand block is not present
6. With this PR fix the Brand block is present

<img width="357" height="189" alt="Capture d’écran 2026-01-15 à 10 19 28" src="https://github.com/user-attachments/assets/86436991-9f50-49f2-9903-60feefe1437a" />

