### PR TITLE
Backport - Use proper, standardized values in quantity input

### DIFF
--- a/config/theme.yml
+++ b/config/theme.yml
@@ -1,6 +1,6 @@
 name: classic
 display_name: Classic
-version: 3.0.5
+version: 3.0.6
 author:
   name: "PrestaShop SA and Contributors"
   email: "contact@prestashop.com"

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -35,13 +35,8 @@
             id="quantity_wanted"
             inputmode="numeric"
             pattern="[0-9]*"
-            {if $product.quantity_wanted}
-              value="{$product.quantity_wanted}"
-              min="{$product.minimal_quantity}"
-            {else}
-              value="1"
-              min="1"
-            {/if}
+            value="{if $product.quantity_wanted}{$product.quantity_wanted}{else}1{/if}"
+            min="{if $product.quantity_required}{$product.quantity_required}{else}1{/if}"
             class="input-group"
             aria-label="{l s='Quantity' d='Shop.Theme.Actions'}"
           >


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Backport of https://github.com/PrestaShop/classic-theme/pull/189. In order to fix all of the issues with product quantities, we cannot use minimum quantity. This fixes all issues and unifies both themes. Required for https://github.com/PrestaShop/PrestaShop/pull/40538.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | TRENDO s.r.o.
| How to test?      | See steps in original issue
