### PR TITLE
Remove  shipping cost  in order details for multi-shipment scenarios

### DIFF
--- a/templates/customer/_partials/order-shipments.tpl
+++ b/templates/customer/_partials/order-shipments.tpl
@@ -5,7 +5,6 @@
         <th>{l s='Date' d='Shop.Theme.Global'}</th>
         <th>{l s='Carrier' d='Shop.Theme.Checkout'}</th>
         <th>{l s='Weight' d='Shop.Theme.Checkout'}</th>
-        <th>{l s='Shipping cost' d='Shop.Theme.Checkout'}</th>
         <th>{l s='Tracking number' d='Shop.Theme.Checkout'}</th>
       </tr>
     </thead>
@@ -15,7 +14,6 @@
           <td>{$line.date_add}</td>
           <td>{$line.carrier_name}</td>
           <td>{$line.package_weight}</td>
-          <td>{$line.package_cost}</td>
           <td>
             {if $line.carrier_tracking_url}
               <a href="{$line.carrier_tracking_url}" target="_blank">{$line.tracking_number}</a>
@@ -41,9 +39,6 @@
           </li>
           <li>
             <strong>{l s='Weight' d='Shop.Theme.Checkout'}</strong> {$line.package_weight}
-          </li>
-          <li>
-            <strong>{l s='Shipping cost' d='Shop.Theme.Checkout'}</strong> {$line.package_cost}
           </li>
           <li>
             <strong>{l s='Tracking number' d='Shop.Theme.Checkout'}</strong>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This can be confusing for the user. What they're interested in is the total shipping cost, which is already included in the totals. Furthermore, after splitting and merging shipments, it's currently impossible to have accurate values ​​in this table.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | -
| Sponsor company   | -
| How to test?      | -
