### PR TITLE
ContactForm: Hide subject dropdown when only one contact is available

### DIFF
--- a/modules/contactform/views/templates/widget/contactform.tpl
+++ b/modules/contactform/views/templates/widget/contactform.tpl
@@ -43,16 +43,21 @@
           </div>
         </div>
 
-        <div class="form-group row">
-          <label class="col-md-3 form-control-label" for="id_contact">{l s='Subject' d='Shop.Forms.Labels'}</label>
-          <div class="col-md-6">
-            <select name="id_contact" id="id_contact" class="form-control form-control-select">
-              {foreach from=$contact.contacts item=contact_elt}
-                <option value="{$contact_elt.id_contact}">{$contact_elt.name}</option>
-              {/foreach}
-            </select>
+        {if $contact.contacts|count === 1}
+          {assign var=firstContact value=current($contact.contacts)}
+          <input type="hidden" name="id_contact" value="{$firstContact.id_contact|escape:'htmlall':'UTF-8'}"/>
+        {else}
+          <div class="form-group row">
+            <label class="col-md-3 form-control-label" for="id_contact">{l s='Subject' d='Shop.Forms.Labels'}</label>
+            <div class="col-md-6">
+              <select name="id_contact" id="id_contact" class="form-control form-control-select">
+                {foreach from=$contact.contacts item=contact_elt}
+                  <option value="{$contact_elt.id_contact}">{$contact_elt.name}</option>
+                {/foreach}
+              </select>
+            </div>
           </div>
-        </div>
+        {/if}
 
         <div class="form-group row">
           <label class="col-md-3 form-control-label" for="email">{l s='Email address' d='Shop.Forms.Labels'}</label>

--- a/modules/contactform/views/templates/widget/contactform.tpl
+++ b/modules/contactform/views/templates/widget/contactform.tpl
@@ -52,7 +52,7 @@
             <div class="col-md-6">
               <select name="id_contact" id="id_contact" class="form-control form-control-select">
                 {foreach from=$contact.contacts item=contact_elt}
-                  <option value="{$contact_elt.id_contact}">{$contact_elt.name}</option>
+                  <option value="{$contact_elt.id_contact|escape:'htmlall':'UTF-8'}">{$contact_elt.name|escape:'htmlall':'UTF-8'}</option>
                 {/foreach}
               </select>
             </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When only one contact is available in the Contact Form module, the subject dropdown is no longer displayed.<br/>Instead of rendering a `<select>` with a single option, the module now automatically sets the `id_contact` value using a hidden input.<br/>This improves the user experience by removing an unnecessary selection while preserving the expected form behavior.
| Type?         | improvement 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | - In the admin panel, go to **Shop Parameters > Contact**<br/> - Delete the contacts, leaving only one<br/> - In the front office, go to the **Contact** page<br/> - The `Subject Heading` label and its related select dropdown should not be displayed
| Related PRs       | https://github.com/PrestaShop/contactform/pull/88

---
### Before
<img width="825" height="484" alt="Classic-before" src="https://github.com/user-attachments/assets/61f4f3d3-4636-454c-9db0-3946cfd78729" />


### After
<img width="825" height="430" alt="Classic-after" src="https://github.com/user-attachments/assets/ad0cb26f-06f2-4b21-be23-8be00127bbdf" />

