### PR TITLE
Fix duplicate breadcrumb block declaration in partial

### DIFF
--- a/templates/_partials/breadcrumb.tpl
+++ b/templates/_partials/breadcrumb.tpl
@@ -24,18 +24,16 @@
  *}
 <nav data-depth="{$breadcrumb.count}" class="breadcrumb">
   <ol>
-    {block name='breadcrumb'}
-      {foreach from=$breadcrumb.links item=path name=breadcrumb}
-        {block name='breadcrumb_item'}
-          <li>
-            {if not $smarty.foreach.breadcrumb.last}
-              <a href="{$path.url}"><span>{$path.title}</span></a>
-            {else}
-              <span>{$path.title}</span>
-            {/if}
-          </li>
-        {/block}
-      {/foreach}
-    {/block}
+    {foreach from=$breadcrumb.links item=path name=breadcrumb}
+      {block name='breadcrumb_item'}
+        <li>
+          {if not $smarty.foreach.breadcrumb.last}
+            <a href="{$path.url}"><span>{$path.title}</span></a>
+          {else}
+            <span>{$path.title}</span>
+          {/if}
+        </li>
+      {/block}
+    {/foreach}
   </ol>
 </nav>

--- a/templates/_partials/breadcrumb.tpl
+++ b/templates/_partials/breadcrumb.tpl
@@ -23,17 +23,21 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 <nav data-depth="{$breadcrumb.count}" class="breadcrumb">
-  <ol>
-    {foreach from=$breadcrumb.links item=path name=breadcrumb}
-      {block name='breadcrumb_item'}
-        <li>
-          {if not $smarty.foreach.breadcrumb.last}
-            <a href="{$path.url}"><span>{$path.title}</span></a>
-          {else}
-            <span>{$path.title}</span>
-          {/if}
-        </li>
+  {block name='breadcrumb_list'}
+    <ol>
+      {block name='breadcrumb_items'}
+        {foreach from=$breadcrumb.links item=path name=breadcrumb}
+          {block name='breadcrumb_item'}
+            <li>
+              {if not $smarty.foreach.breadcrumb.last}
+                <a href="{$path.url}"><span>{$path.title}</span></a>
+              {else}
+                <span>{$path.title}</span>
+              {/if}
+            </li>
+          {/block}
+        {/foreach}
       {/block}
-    {/foreach}
-  </ol>
+    </ol>
+  {/block}
 </nav>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR fixes the breadcrumb block structure to avoid declaring the same` {block name='breadcrumb'}` in both `layout-both-columns.tpl` and `breadcrumb.tpl`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | Codencode snc
| How to test?      | 
