### PR TITLE
Do not call html() on an empty carrier extra content collection

### DIFF
--- a/_dev/js/checkout.js
+++ b/_dev/js/checkout.js
@@ -79,7 +79,7 @@ $(document).ready(() => {
     // Show the one related to the selected carrier
     const carrierExtraContent = params.deliveryOption.next(prestashop.themeSelectors.checkout.carrierExtraContent);
 
-    if (carrierExtraContent.html().trim() !== '') {
+    if (carrierExtraContent.length && carrierExtraContent.html().trim() !== '') {
       carrierExtraContent.slideDown();
     }
   });


### PR DESCRIPTION
| Questions                | Answers
| ------------------------ | -------------------------------------------------------
| Branch?                  | 2.2.x
| Description?             | `updatedDeliveryForm` calls `.html()` on the result of `.next('.carrier-extra-content')`. When that selector matches nothing, jQuery returns an empty collection, `.html()` returns `undefined` and `.trim()` throws on every carrier change. This adds the missing length check.
| Type?                    | bug fix
| Category?                | FO
| BC breaks?               | no
| Deprecations?            | no
| How to test?             | See below.
| Fixed issue or discussion? | #214
| Sponsor company          | OpenServis.cz

### Why

Nothing guarantees that `.carrier-extra-content` stays the immediate next sibling of `.delivery-option`. Any element inserted in between makes `.next()` return an empty collection, which is a common situation once a pickup point module places its selector next to the carrier row.

The exception is also hard to diagnose, because jQuery 3 converts it into a rejection and the `.fail()` branch in `themes/_core/js/checkout-delivery.js` then calls `prestashop.trigger(...)`, a method the emitter does not have. The console only shows `r(...).trigger is not a function`, and the real cause stays hidden. That second problem lives in the main repository and is not addressed here.

The guard being fixed was introduced in 2.1.x by acd52d3e (#157) to solve PrestaShop/PrestaShop#37194, and this change keeps that behaviour: the extra content is still only slid down when it actually has content.

The `develop` branch is not affected, it calls `slideDown()` directly and jQuery ignores an empty set there.

### How to test

1. PrestaShop 8.2.1 or later with the Classic theme, at least two carriers in the checkout, one of them rendering a `.carrier-extra-content` block.
2. On the shipping step, run `$('.delivery-option').first().after('<div></div>');` in the console to simulate a module inserting an element between the carrier row and its extra content.
3. Select another carrier.
4. Before this change the console shows a `TypeError`. After it, the carrier switch is silent and the extra content of the selected carrier still expands when it has content.
