### PR TITLE
Skip the logo markup when a brand or supplier has none

### DIFF
--- a/templates/catalog/_partials/miniatures/brand.tpl
+++ b/templates/catalog/_partials/miniatures/brand.tpl
@@ -25,18 +25,20 @@
 {block name='brand_miniature_item'}
   <li class="brand">
     <div class="brand-img">
-      <a href="{$brand.url}">
-        <picture>
-          {if !empty($brand.image.bySize.small_default.sources.avif)}<source srcset="{$brand.image.bySize.small_default.sources.avif}" type="image/avif">{/if}
-          {if !empty($brand.image.bySize.small_default.sources.webp)}<source srcset="{$brand.image.bySize.small_default.sources.webp}" type="image/webp">{/if}
-          <img
-            src="{$brand.image.bySize.small_default.url}"
-            alt="{if !empty($brand.image.legend)}{$brand.image.legend}{else}{$brand.name}{/if}"
-            class="img-fluid"
-            loading="lazy"
-          >
-        </picture>
-      </a>
+      {if !empty($brand.image.bySize.small_default.url)}
+        <a href="{$brand.url}">
+          <picture>
+            {if !empty($brand.image.bySize.small_default.sources.avif)}<source srcset="{$brand.image.bySize.small_default.sources.avif}" type="image/avif">{/if}
+            {if !empty($brand.image.bySize.small_default.sources.webp)}<source srcset="{$brand.image.bySize.small_default.sources.webp}" type="image/webp">{/if}
+            <img
+              src="{$brand.image.bySize.small_default.url}"
+              alt="{if !empty($brand.image.legend)}{$brand.image.legend}{else}{$brand.name}{/if}"
+              class="img-fluid"
+              loading="lazy"
+            >
+          </picture>
+        </a>
+      {/if}
     </div>
     <div class="brand-infos">
       <p><a href="{$brand.url}">{$brand.name}</a></p>

--- a/templates/catalog/_partials/miniatures/supplier.tpl
+++ b/templates/catalog/_partials/miniatures/supplier.tpl
@@ -25,18 +25,20 @@
 {block name='supplier_miniature_item'}
   <li class="supplier">
     <div class="supplier-img">
-      <a href="{$supplier.url}">
-        <picture>
-          {if !empty($supplier.image.bySize.small_default.sources.avif)}<source srcset="{$supplier.image.bySize.small_default.sources.avif}" type="image/avif">{/if}
-          {if !empty($supplier.image.bySize.small_default.sources.webp)}<source srcset="{$supplier.image.bySize.small_default.sources.webp}" type="image/webp">{/if}
-          <img
-            src="{$supplier.image.bySize.small_default.url}"
-            alt="{if !empty($supplier.image.legend)}{$supplier.image.legend}{else}{$supplier.name}{/if}"
-            class="img-fluid"
-            loading="lazy"
-          >
-        </picture>
-      </a>
+      {if !empty($supplier.image.bySize.small_default.url)}
+        <a href="{$supplier.url}">
+          <picture>
+            {if !empty($supplier.image.bySize.small_default.sources.avif)}<source srcset="{$supplier.image.bySize.small_default.sources.avif}" type="image/avif">{/if}
+            {if !empty($supplier.image.bySize.small_default.sources.webp)}<source srcset="{$supplier.image.bySize.small_default.sources.webp}" type="image/webp">{/if}
+            <img
+              src="{$supplier.image.bySize.small_default.url}"
+              alt="{if !empty($supplier.image.legend)}{$supplier.image.legend}{else}{$supplier.name}{/if}"
+              class="img-fluid"
+              loading="lazy"
+            >
+          </picture>
+        </a>
+      {/if}
     </div>
     <div class="supplier-infos">
       <p><a href="{$supplier.url}">{$supplier.name}</a></p>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The brand and supplier listing miniatures read `image.bySize.small_default.url` unconditionally. Since PrestaShop/PrestaShop#41699 landed in core, `ManufacturerLazyArray::getImage()` and `SupplierLazyArray::getImage()` return `null` when no logo file exists, so on `/brands` and `/suppliers` every logo-less entity now dereferences `null` three times over. The `<source>` lines were already guarded with `!empty`; only the `<img src>` was not. This wraps the `<picture>` in the same guard, so an entity without a logo renders no image markup instead of a broken one. Its name is still shown, linked, by the `brand-infos` / `supplier-infos` block right below.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | PrestaShop/PrestaShop#41692
| Sponsor company   | -
| How to test?      | Create a brand with no logo and open `/brands` with this theme active. Before this change the page emits `Trying to access array offset on value of type null` and, because the warning is printed inside the attribute, the tag comes out as `src="<br /><b>Warning</b>: ..."`; with warnings off it is `src=""`, which the browser resolves as a second request for the page itself. After the change there is no image element and no warning, and brands that do have a logo are unaffected. Suppliers are the same page-for-page, and note that on a stock install `img/su/` has no logo files at all, so `/suppliers` reproduces it for every row once `PS_DISPLAY_SUPPLIERS` is on.

Measured on a 9.2.0 shop with this theme active, counting the warning in the rendered HTML:

```
/brands      3 warnings -> 0     (one logo-less brand; the two with a logo still render theirs)
/suppliers   6 warnings -> 0     (two logo-less suppliers, three null offsets each)
```

Three warnings per row is the whole chain being walked on `null`: `image['bySize']`, then `['small_default']`, then `['url']`.

One choice worth naming, since it is a judgement call rather than a forced one. When there is no logo I render nothing in the image slot, keeping the surrounding `brand-img` / `supplier-img` container so the grid does not reflow. The alternative would be a text fallback inside that slot, which is what the Hummingbird product page does - but on this listing the name is already immediately below in `brand-infos`, so it would print twice. If you would rather have the placeholder image back for logo-less rows, that is a one-line change to the same guard and I will redo it.
