### PR TITLE
Stop showing the No tax label when taxes are disabled

### DIFF
--- a/templates/catalog/_partials/product-prices.tpl
+++ b/templates/catalog/_partials/product-prices.tpl
@@ -91,9 +91,7 @@
     {hook h='displayProductPriceBlock' product=$product type="weight" hook_origin='product_sheet'}
 
     <div class="tax-shipping-delivery-label">
-      {if !$configuration.taxes_enabled}
-        {l s='No tax' d='Shop.Theme.Catalog'}
-      {elseif $configuration.display_taxes_label}
+      {if $configuration.taxes_enabled && $configuration.display_taxes_label}
         {$product.labels.tax_long}
       {/if}
       {hook h='displayProductPriceBlock' product=$product type="price"}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | With taxes disabled shop-wide, the product page prints `No tax` on every product while the cart prints nothing, so a shop that is not liable for VAT carries the string in one place only.<br><br>The two are not written the same way. `cart-summary-totals.tpl` requires both flags before showing any tax label, `{if $configuration.display_taxes_label && $configuration.taxes_enabled}`, whereas this block short-circuits on the first one and prints `No tax` regardless of the country's display tax label setting.<br><br>The condition now matches the cart. With taxes on, nothing changes: that branch was already gated on `display_taxes_label`. With taxes off, the label is omitted, as it already is in the cart.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#19562
| Sponsor company   | -
| How to test?      | Set Shop parameters > Taxes > Enable tax to No, then open any product page. Before: `No tax` under the price. After: nothing there, matching the cart summary.<br><br>With tax enabled the page is unchanged, and with a country whose "Display tax label" is off the long label stays hidden as before.

`No tax` is the only wording removed and it has no other use in this theme, so nothing else needs translating.

The same block exists in Hummingbird and behaves identically; a companion PR follows there if this direction is right.
