### PR TITLE
Move both thumbnail selection classes together when swiping

### DIFF
--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -36,9 +36,12 @@ $(document).ready(() => {
     const swipe = (selectedThumb, thumbParent) => {
       const newSelectedThumb = thumbParent.find(prestashop.themeSelectors.product.thumb);
 
-      // Swap active classes on thumbnail
-      selectedThumb.removeClass('selected');
-      newSelectedThumb.addClass('selected');
+      // Swap active classes on thumbnail. Both have to move together: "selected" carries the
+      // styling and "js-thumb-selected" is what themeSelectors.product.selected looks for, so
+      // dropping only one of them leaves the previous thumbnail matching that selector and the
+      // next swipe acts on a growing set of thumbnails.
+      selectedThumb.removeClass('selected js-thumb-selected');
+      newSelectedThumb.addClass('selected js-thumb-selected');
 
       // Update sources of both cover and modal cover
       modalProductCover.prop('src', newSelectedThumb.data('image-large-src'));


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The default thumbnail is rendered with **two** classes, `selected` and `js-thumb-selected` (`product-cover-thumbnails.tpl:74`), and `themeSelectors.product.selected` is `'.selected, .js-thumb-selected'` — it matches either. `swipe()` removed only `selected` from the outgoing thumbnail, so that thumbnail kept `js-thumb-selected` and carried on matching the selector.<br><br>Every later swipe therefore read a *set* of thumbnails instead of one, called `.closest().next()` on all of them and marked each result selected. That is both reported symptoms: the highlight spreads across the strip, and stepping through the images stops working part way.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#33782
| Sponsor company   | -
| How to test?      | Open a product with four or more images on a touch device or with device emulation, and swipe the cover sideways repeatedly. Before this change a second and third thumbnail light up and the cover stops following the swipes; after, exactly one thumbnail is highlighted and the cover advances through every image.

### Measured

The two lines that change are pure class handling, so the mechanism was measured directly: the markup
`product-cover-thumbnails.tpl` emits for a four-image product, the selectors from `selectors.js`
verbatim, and the same `.closest()` / `.next()` walk `swipe()` performs, run three times.

```
                    matched by themeSelectors.product.selected   visibly highlighted   thumbnails
shipped   swipe 1                    2                                   1              1,2
          swipe 2                    3                                   2              1,2,3
          swipe 3                    4                                   3              1,2,3,4

with fix  swipe 1                    1                                   1              2
          swipe 2                    1                                   1              3
          swipe 3                    1                                   1              4
```

The left column is the defect: the matched set grows by one on every swipe, because each outgoing
thumbnail keeps `js-thumb-selected`. The right-hand run advances one image at a time, which is the
intended behaviour.

### Scope

Only the class pair is touched. `js-thumb-selected` has exactly three references in the theme — the
selector, the template, and these two lines — so nothing else depends on it being left behind:

```
_dev/js/selectors.js:51                                 selected: '.selected, .js-thumb-selected'
templates/catalog/_partials/product-cover-thumbnails.tpl:74   default thumb gets both
_dev/js/product.js:43-44                                the swap (this change)
```

The click handler above shares the same `swipe()` function, so it is fixed by the same two lines.

### Checks

`npx eslint -c .eslintrc.js js/product.js` exits 0. `assets/` is gitignored in this repository, so no
rebuilt bundle belongs in the diff.

### Verification limit

Measured on the real markup and selectors with the real DOM operations, not by swiping on a device — the
touch gesture is delivered by `jquery.touchSwipe`, which only decides *when* `swipe()` is called, not
what it does. The class bookkeeping inside it is what was wrong and what is measured above.
