### PR TITLE
Submit the guest order tracking form with POST

### DIFF
--- a/templates/customer/guest-login.tpl
+++ b/templates/customer/guest-login.tpl
@@ -29,7 +29,11 @@
 {/block}
 
 {block name='page_content'}
-  <form id="guestOrderTrackingForm" action="{$urls.pages.guest_tracking}" method="get">
+  {* Submitted with POST so the shopper's email address does not end up in the URL, where it reaches
+     analytics as a page path, the browser history, the access log and any referrer. The controller reads
+     the fields with Tools::getValue(), which takes POST as well, and links that already carry the
+     parameters in a query string keep working. *}
+  <form id="guestOrderTrackingForm" action="{$urls.pages.guest_tracking}" method="post">
     <header>
       <p>{l s='To track your order, please enter the following information:' d='Shop.Theme.Customeraccount'}</p>
     </header>


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?    | The guest order tracking form is submitted with GET, so the shopper's email address ends up in the URL. It is then recorded by analytics as a page path, kept in the browser history, and written to the access log and any referrer. Submitting it with POST keeps the address out of the URL.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | PrestaShop/PrestaShop#13911
| Sponsor company | -
| How to test?    | See below.

### Why

`templates/customer/guest-login.tpl` submits the tracking form with `method="get"`, and the form holds a
field named `email`. Submitting it therefore produces a URL of the shape
`/guest-tracking?order_reference=...&email=someone@example.com`.

That is the report in PrestaShop/PrestaShop#13911: email addresses visible in Google Analytics page
paths. A URL carrying the address does not only reach analytics — it is also kept in the browser history,
written to the web server access log, and sent as the referrer to anything the page loads.

### What it does

Switches the form to `method="post"`.

`Tools::getValue()` reads `$_POST` before `$_GET` (`classes/Tools.php`), and `GuestTrackingController`
reads `order_reference` and `email` through it, so no controller change is needed. Links that already
carry the parameters in a query string keep working, since the controller still accepts them.

The hidden `controller` input is left in place. It exists because a GET form replaces the action's query
string with its own fields; with POST the action's query string is preserved and the input is simply
harmless.

### How to test

1. Front office, open the guest order tracking page.
2. Fill in an order reference and an email, submit.
3. Before: the address bar shows `...&email=someone@example.com`. After: the URL carries no email.
4. A link that already carries `?order_reference=...&email=...` still resolves the order.
