### PR TITLE
Show why an add to cart was rejected instead of doing nothing

### DIFF
--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -168,6 +168,32 @@ $(document).ready(() => {
   imageScrollBox();
   addJsProductTabActiveSelector();
 
+  /**
+   * Core reports a rejected "add to cart" - out of stock, minimum quantity, no longer available -
+   * by emitting `handleError`, and then stops. Nothing in this theme listened, so the customer got
+   * no feedback at all: the button did nothing and the reason only appeared after a page reload.
+   *
+   * Scoped to the add-to-cart case on purpose. The other `handleError` emitters cover pages with no
+   * availability slot to write into, and a catch-all listener would start surfacing messages they
+   * never showed before.
+   */
+  prestashop.on('handleError', (event) => {
+    if (!event || event.eventType !== 'addProductToCart') {
+      return;
+    }
+
+    // The `.fail()` emitters pass a jqXHR, which carries no `errors`.
+    const errors = event.resp && event.resp.errors;
+
+    if (!Array.isArray(errors) || errors.length === 0) {
+      return;
+    }
+
+    prestashop.emit('showErrorNextToAddtoCartButton', {
+      errorMessage: errors.join(' '),
+    });
+  });
+
   prestashop.on('updatedProduct', (event) => {
     createInputFile();
     coverImage();


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?    | Adding a product to the cart from the product page when it has just gone out of stock does nothing visible: no modal, no message. The server answers correctly - `CartController` returns `{"hasError":true,"errors":["This product ... is no longer available."]}` - and `themes/_core/js/cart.js` turns that into `prestashop.emit('handleError', {eventType: 'addProductToCart', resp})`. Nothing in this theme listened, so the message was dropped and the reason only surfaced after a reload. Hummingbird already registers such a listener; classic never did. This adds it.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | PrestaShop/PrestaShop#16260
| Sponsor company | -
| How to test?    | Set a product to out of stock with "Deny orders" and open its product page in this theme, then click "Add to cart". Before this change nothing happens and `prestashop._events.handleError` has 0 listeners; after it, the error text from the server is displayed. A product that is in stock still adds normally.

Measured on a 9.2.x shop with classic 3.1.2, on `upstream/develop`'s own build:

```
prestashop._events.handleError                    -> 0 listeners
click "Add to cart" on a now-out-of-stock product
  events emitted                                  -> ["handleError"]
  #product-availability                           -> unchanged
  .alert-danger                                   -> none
  page text contains "no longer available"        -> false
```

Only `_dev/js/product.js` is changed; no built asset is in the diff.
