### PR TITLE
Give the quantity spinner buttons an accessible name

### DIFF
--- a/_dev/js/cart.js
+++ b/_dev/js/cart.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import prestashop from 'prestashop';
+import applyTouchspinLabels from './components/touchspin-labels';
 import debounce from './components/debounce';
 
 prestashop.cart = prestashop.cart || {};
@@ -79,6 +80,8 @@ function createSpin() {
       min: parseInt($(spinner).attr('min'), 10),
       max: 1000000,
     });
+
+    applyTouchspinLabels($(spinner));
   });
 
   $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');

--- a/_dev/js/components/touchspin-labels.js
+++ b/_dev/js/components/touchspin-labels.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+/**
+ * Gives the buttons TouchSpin generates an accessible name.
+ *
+ * The buttons hold nothing but an icon element, so assistive technology and accessibility
+ * checkers see an unnamed button. TouchSpin builds them itself, after the template has been
+ * rendered, which is why the labels travel on the input as data attributes and are applied here
+ * rather than written in the template.
+ *
+ * @param {jQuery} $input the quantity input TouchSpin was initialised on
+ */
+export default function applyTouchspinLabels($input) {
+  const increase = $input.data('increaseLabel');
+  const decrease = $input.data('decreaseLabel');
+  const $group = $input.closest('.bootstrap-touchspin');
+
+  if (increase) {
+    $group.find('.bootstrap-touchspin-up').attr('aria-label', increase);
+  }
+
+  if (decrease) {
+    $group.find('.bootstrap-touchspin-down').attr('aria-label', decrease);
+  }
+}

--- a/_dev/js/listing.js
+++ b/_dev/js/listing.js
@@ -24,6 +24,7 @@
  */
 import $ from 'jquery';
 import prestashop from 'prestashop';
+import applyTouchspinLabels from './components/touchspin-labels';
 // eslint-disable-next-line
 import "velocity-animate";
 import updateSources from './components/update-sources';
@@ -106,6 +107,8 @@ $(document).ready(() => {
       min: 1,
       max: 1000000,
     });
+
+    applyTouchspinLabels(qv.find(prestashop.selectors.quantityWanted));
 
     $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
   };

--- a/_dev/js/product.js
+++ b/_dev/js/product.js
@@ -24,6 +24,7 @@
  */
 import $ from 'jquery';
 import prestashop from 'prestashop';
+import applyTouchspinLabels from './components/touchspin-labels';
 import ProductSelect from './components/product-select';
 import updateSources from './components/update-sources';
 
@@ -127,6 +128,8 @@ $(document).ready(() => {
       min: parseInt($quantityInput.attr('min'), 10),
       max: 1000000,
     });
+
+    applyTouchspinLabels($quantityInput);
 
     $(prestashop.themeSelectors.touchspin).off('touchstart.touchspin');
 

--- a/templates/catalog/_partials/product-add-to-cart.tpl
+++ b/templates/catalog/_partials/product-add-to-cart.tpl
@@ -39,6 +39,8 @@
             min="{if $product.quantity_required}{$product.quantity_required}{else}1{/if}"
             class="input-group"
             aria-label="{l s='Quantity' d='Shop.Theme.Actions'}"
+            data-increase-label="{l s='Increase quantity' d='Shop.Theme.Actions'}"
+            data-decrease-label="{l s='Decrease quantity' d='Shop.Theme.Actions'}"
           >
         </div>
 

--- a/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -136,6 +136,8 @@
             {else}
               <input
                 class="js-cart-line-product-quantity"
+                data-increase-label="{l s='Increase quantity' d='Shop.Theme.Actions'}"
+                data-decrease-label="{l s='Decrease quantity' d='Shop.Theme.Actions'}"
                 data-down-url="{$product.down_quantity_url}"
                 data-up-url="{$product.up_quantity_url}"
                 data-update-url="{$product.update_quantity_url}"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | TouchSpin builds the increase/decrease buttons itself and puts nothing in them but an icon element, so accessibility checkers report "a button is empty or has no value text" and screen readers announce two unnamed buttons. The buttons do not exist until TouchSpin has run, so the labels travel on the quantity input as data attributes - where they can be translated - and are applied to the generated buttons right after initialisation. Done at all three places the spinner is built: product page, quick view and cart.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes https://github.com/PrestaShop/PrestaShop/issues/26778
| Sponsor company |
| How to test?    | Open a product page in the classic theme and inspect the two quantity buttons: they now carry `aria-label="Increase quantity"` / `"Decrease quantity"`. Same in the quick view and on each cart line. Run WAVE or any checker over the page - the "empty button" errors for the quantity control are gone.

> classic-theme's PR table has no `Branch?` / `Category?` / `UI Tests` rows - copy the live template at
> publish time. See [[classic-theme-is-a-separate-repo]].

### Measured on the real front office, both directions

The shop was switched to `classic` and the page loaded in a browser (the buttons do not exist in the
server HTML - TouchSpin creates them client-side, which is why this cannot be checked with curl):

```
before   2 buttons, text "", aria-label null, title null   (input itself already had aria-label="Quantity")
after    up   -> aria-label="Increase quantity"
         down -> aria-label="Decrease quantity"
```

### Hummingbird is already correct - this is classic only

The default 9.x theme renders the buttons in its own template with
`aria-label="Decrease quantity of <product name>"` and `aria-hidden="true"` on the icons. Verified on the
live front office. So the report is still valid, but only for the theme it was filed against, and
@matks's 2023 comment that the new theme does better is accurate.

### Gates

- `npm run lint` (eslint) clean after fixing two issues it caught: an unused `$` import in the new helper
  and `import/order`.
- `npm run build` succeeds; `assets/` is gitignored in this repo so no built bundle is in the diff.
- No automated a11y test exists in this theme; the before/after above is the evidence.