### PR TITLE
Stop nesting form elements in the checkout address step

### DIFF
--- a/templates/checkout/_partials/address-form.tpl
+++ b/templates/checkout/_partials/address-form.tpl
@@ -34,13 +34,15 @@
     <button type="submit" class="btn btn-primary float-xs-right">{l s='Save' d='Shop.Theme.Actions'}</button>
     <a class="js-cancel-address cancel-address float-xs-right" href="{url entity='order' params=['cancelAddress' => {$type}]}">{l s='Cancel' d='Shop.Theme.Actions'}</a>
   {else}
-    <form>
+    {* WHY: not a <form>. This block is rendered inside the address form, so a nested form here is
+       dropped by the HTML parser while its </form> closes the address form early. *}
+    <div class="clearfix">
       <button type="submit" class="continue btn btn-primary float-xs-right" name="confirm-addresses" value="1">
           {l s='Continue' d='Shop.Theme.Actions'}
       </button>
       {if $customer.addresses|count > 0}
         <a class="js-cancel-address cancel-address float-xs-right" href="{url entity='order' params=['cancelAddress' => {$type}]}">{l s='Cancel' d='Shop.Theme.Actions'}</a>
       {/if}
-    </form>
+    </div>
   {/if}
 {/block}

--- a/templates/checkout/_partials/address-selector-block.tpl
+++ b/templates/checkout/_partials/address-selector-block.tpl
@@ -35,6 +35,7 @@
               type="radio"
               name="{$name}"
               value="{$address.id}"
+              {if isset($form_id)}form="{$form_id}"{/if}
               {if $address.id == $selected}checked{/if}
             >
             <span></span>
@@ -66,7 +67,7 @@
   {/foreach}
   {if $interactive}
     <p>
-      <button class="ps-hidden-by-js form-control-submit center-block" type="submit">{l s='Save' d='Shop.Theme.Actions'}</button>
+      <button class="ps-hidden-by-js form-control-submit center-block" type="submit"{if isset($form_id)} form="{$form_id}"{/if}>{l s='Save' d='Shop.Theme.Actions'}</button>
     </p>
   {/if}
 {/block}

--- a/templates/checkout/_partials/steps/addresses.tpl
+++ b/templates/checkout/_partials/steps/addresses.tpl
@@ -25,113 +25,121 @@
 {extends file='checkout/_partials/steps/checkout-step.tpl'}
 
 {block name='step_content'}
+  {$addresses_form_id = 'checkout-addresses-form'}
   <div class="js-address-form">
+    {* WHY: this step also renders full address <form> elements (checkout/_partials/address-form.tpl).
+       Wrapping those in this form produced nested <form> tags: the HTML parser drops the inner start
+       tag and lets the inner </form> close THIS form instead, which orphaned the address selector and
+       the Continue button that follow it. This form therefore stays empty and its controls are
+       attached explicitly through the form attribute. *}
     <form
+      id="{$addresses_form_id}"
       method="POST"
       data-id-address="{$id_address}"
       action="{url entity='order' params=['id_address' => $id_address]}"
       data-refresh-url="{url entity='order' params=['ajax' => 1, 'action' => 'addressForm']}"
-    >
+    ></form>
 
-      {if $use_same_address}
-        <p>
-          {if $cart.is_virtual}
-            {l s='The selected address will be used as your personal address (for invoice).' d='Shop.Theme.Checkout'}
-          {else}
-            {l s='The selected address will be used both as your personal address (for invoice) and as your delivery address.' d='Shop.Theme.Checkout'}
-          {/if}
-        </p>
+    {if $use_same_address}
+      <p>
+        {if $cart.is_virtual}
+          {l s='The selected address will be used as your personal address (for invoice).' d='Shop.Theme.Checkout'}
+        {else}
+          {l s='The selected address will be used both as your personal address (for invoice) and as your delivery address.' d='Shop.Theme.Checkout'}
+        {/if}
+      </p>
+    {else}
+      <h2 class="h4">{l s='Shipping Address' d='Shop.Theme.Checkout'}</h2>
+    {/if}
+
+    {if $show_delivery_address_form}
+      <div id="delivery-address">
+        {render file                      = 'checkout/_partials/address-form.tpl'
+          ui                        = $address_form
+          use_same_address          = $use_same_address
+          type                      = "delivery"
+          form_has_continue_button  = $form_has_continue_button
+        }
+      </div>
+    {elseif $customer.addresses|count > 0}
+      <div id="delivery-addresses" class="address-selector js-address-selector">
+        {include  file        = 'checkout/_partials/address-selector-block.tpl'
+          addresses   = $customer.addresses
+          name        = "id_address_delivery"
+          selected    = $id_address_delivery
+          type        = "delivery"
+          form_id     = $addresses_form_id
+          interactive = !$show_delivery_address_form and !$show_invoice_address_form
+        }
+      </div>
+
+      {if isset($delivery_address_error)}
+        <p class="alert alert-danger js-address-error" name="alert-delivery" id="id-failure-address-{$delivery_address_error.id_address}">{$delivery_address_error.exception}</p>
       {else}
-        <h2 class="h4">{l s='Shipping Address' d='Shop.Theme.Checkout'}</h2>
+        <p class="alert alert-danger js-address-error" name="alert-delivery" style="display: none">{l s="Your address is incomplete, please update it." d="Shop.Notifications.Error"}</p>
       {/if}
 
-      {if $show_delivery_address_form}
-        <div id="delivery-address">
+      <p class="add-address">
+        <a href="{$new_address_delivery_url}"><i class="material-icons">&#xE145;</i>{l s='add new address' d='Shop.Theme.Actions'}</a>
+      </p>
+
+      {if $use_same_address && !$cart.is_virtual}
+        <p>
+          <a data-link-action="different-invoice-address" href="{$use_different_address_url}">
+            {l s='Billing address differs from shipping address' d='Shop.Theme.Checkout'}
+          </a>
+        </p>
+      {/if}
+
+    {/if}
+
+    {if !$use_same_address}
+
+      <h2 class="h4">{l s='Your Invoice Address' d='Shop.Theme.Checkout'}</h2>
+
+      {if $show_invoice_address_form}
+        <div id="invoice-address">
           {render file                      = 'checkout/_partials/address-form.tpl'
             ui                        = $address_form
             use_same_address          = $use_same_address
-            type                      = "delivery"
+            type                      = "invoice"
             form_has_continue_button  = $form_has_continue_button
           }
         </div>
-      {elseif $customer.addresses|count > 0}
-        <div id="delivery-addresses" class="address-selector js-address-selector">
+      {else}
+        <div id="invoice-addresses" class="address-selector js-address-selector">
           {include  file        = 'checkout/_partials/address-selector-block.tpl'
             addresses   = $customer.addresses
-            name        = "id_address_delivery"
-            selected    = $id_address_delivery
-            type        = "delivery"
+            name        = "id_address_invoice"
+            selected    = $id_address_invoice
+            type        = "invoice"
+            form_id     = $addresses_form_id
             interactive = !$show_delivery_address_form and !$show_invoice_address_form
           }
         </div>
 
-        {if isset($delivery_address_error)}
-          <p class="alert alert-danger js-address-error" name="alert-delivery" id="id-failure-address-{$delivery_address_error.id_address}">{$delivery_address_error.exception}</p>
+        {if isset($invoice_address_error)}
+          <p class="alert alert-danger js-address-error" name="alert-invoice" id="id-failure-address-{$invoice_address_error.id_address}">{$invoice_address_error.exception}</p>
         {else}
-          <p class="alert alert-danger js-address-error" name="alert-delivery" style="display: none">{l s="Your address is incomplete, please update it." d="Shop.Notifications.Error"}</p>
+          <p class="alert alert-danger js-address-error" name="alert-invoice" style="display: none">{l s="Your address is incomplete, please update it." d="Shop.Notifications.Error"}</p>
         {/if}
 
         <p class="add-address">
-          <a href="{$new_address_delivery_url}"><i class="material-icons">&#xE145;</i>{l s='add new address' d='Shop.Theme.Actions'}</a>
+          <a href="{$new_address_invoice_url}"><i class="material-icons">&#xE145;</i>{l s='add new address' d='Shop.Theme.Actions'}</a>
         </p>
-
-        {if $use_same_address && !$cart.is_virtual}
-          <p>
-            <a data-link-action="different-invoice-address" href="{$use_different_address_url}">
-              {l s='Billing address differs from shipping address' d='Shop.Theme.Checkout'}
-            </a>
-          </p>
-        {/if}
-
       {/if}
 
-      {if !$use_same_address}
+    {/if}
 
-        <h2 class="h4">{l s='Your Invoice Address' d='Shop.Theme.Checkout'}</h2>
+    {if !$form_has_continue_button}
+      <div class="clearfix">
+        <button type="submit" class="btn btn-primary continue float-xs-right" name="confirm-addresses" value="1" form="{$addresses_form_id}">
+          {l s='Continue' d='Shop.Theme.Actions'}
+        </button>
+        <input type="hidden" id="not-valid-addresses" class="js-not-valid-addresses" form="{$addresses_form_id}" value="{$not_valid_addresses}">
+      </div>
+    {/if}
 
-        {if $show_invoice_address_form}
-          <div id="invoice-address">
-            {render file                      = 'checkout/_partials/address-form.tpl'
-              ui                        = $address_form
-              use_same_address          = $use_same_address
-              type                      = "invoice"
-              form_has_continue_button  = $form_has_continue_button
-            }
-          </div>
-        {else}
-          <div id="invoice-addresses" class="address-selector js-address-selector">
-            {include  file        = 'checkout/_partials/address-selector-block.tpl'
-              addresses   = $customer.addresses
-              name        = "id_address_invoice"
-              selected    = $id_address_invoice
-              type        = "invoice"
-              interactive = !$show_delivery_address_form and !$show_invoice_address_form
-            }
-          </div>
-
-          {if isset($invoice_address_error)}
-            <p class="alert alert-danger js-address-error" name="alert-invoice" id="id-failure-address-{$invoice_address_error.id_address}">{$invoice_address_error.exception}</p>
-          {else}
-            <p class="alert alert-danger js-address-error" name="alert-invoice" style="display: none">{l s="Your address is incomplete, please update it." d="Shop.Notifications.Error"}</p>
-          {/if}
-
-          <p class="add-address">
-            <a href="{$new_address_invoice_url}"><i class="material-icons">&#xE145;</i>{l s='add new address' d='Shop.Theme.Actions'}</a>
-          </p>
-        {/if}
-
-      {/if}
-
-      {if !$form_has_continue_button}
-        <div class="clearfix">
-          <button type="submit" class="btn btn-primary continue float-xs-right" name="confirm-addresses" value="1">
-            {l s='Continue' d='Shop.Theme.Actions'}
-          </button>
-          <input type="hidden" id="not-valid-addresses" class="js-not-valid-addresses" value="{$not_valid_addresses}">
-        </div>
-      {/if}
-
-    </form>
     {hook h='displayAddressSelectorBottom'}
   </div>
 {/block}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The checkout address step opens a `<form>` around the whole block and then renders full address `<form>` elements inside it, and `checkout/_partials/address-form.tpl` opens a third `<form>` around the Continue button. HTML forbids nesting, and the parser resolves it by ignoring the inner start tag and letting the inner `</form>` close the OUTER form - so every control rendered after an address form loses its form owner. This attaches the step's own controls (address selector radios, Continue button, `not-valid-addresses`) to the step form through the `form` attribute, leaves that form element empty so the address forms are siblings rather than children, and replaces the buttons-block `<form>` with a `<div>`, which is what hummingbird already does.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | PrestaShop/PrestaShop#36563
| Sponsor company   | -
| How to test?      | On a 9.2 shop with this theme active: reach checkout with two saved addresses, click "Billing address differs from shipping address", then "Edit" on the delivery address. Before this change the Continue button, both invoice radios and `#not-valid-addresses` have no form owner (`document.querySelector('button[name=confirm-addresses]').form` is `null`), so Continue does nothing. After, all three belong to the step form.

Measured on 9.2.0 with classic 3.1.2, counting `<form>` tags in the address step of the served HTML and reading form ownership from the parsed DOM:

```
state                                        before          after
2 addresses, editAddress=delivery      10 tags depth 2   10 tags depth 1
1 address,   editAddress=delivery      16 tags depth 3   12 tags depth 1
```

Depth 3 is the case in the issue's screenshot: step form, then the address form, then the buttons-block form.

Form ownership in the two-address state, before -> after:

```
button[name=confirm-addresses]   null -> the step form
input[name=id_address_invoice]   null -> the step form   (both radios)
#not-valid-addresses             null -> the step form
```

## Why the `form` attribute rather than moving the markup

The step form is needed for the address selectors and the Continue button; the address form is needed for
the address fields. They are never the same submission, but they interleave: a delivery selector can be
followed by an invoice form, so no arrangement of open/close tags puts every selector in the same form as
the Continue button. Explicit form ownership is the platform feature for exactly that, and it keeps source
order, markup and CSS unchanged.

## Companion

`PrestaShop/hummingbird` needs the same change (branch `fix/checkout-address-form-nesting-36563`); its
`address-form.tpl` already uses a `<div>` for the buttons block, so only the step-form half applies there,
plus a one-line fix to `initFormValidation` which looked the submit button up with `querySelector` and so
only saw DOM descendants.
