### PR TITLE
Expose Tether's default export, not the module namespace

### DIFF
--- a/_dev/js/theme.js
+++ b/_dev/js/theme.js
@@ -23,7 +23,11 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  */
 /* eslint-disable */
-import 'expose-loader?exposes=Tether!tether';
+// tether 2.x ships an ES module whose default export is the class, and webpack resolves it through
+// the package's `module` field, so exposing the import itself puts the namespace object on
+// window.Tether - `new Tether(...)` then throws "Tether is not a constructor" and Bootstrap's
+// tooltips and popovers stay broken. `|default` exposes the export instead of the namespace.
+import 'expose-loader?exposes=Tether|default!tether';
 import 'bootstrap/dist/js/bootstrap.min';
 import 'flexibility';
 import 'bootstrap-touchspin';


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | `tether@2.0.0` declares `module: dist/js/tether.esm.js`, whose last line is `export default Tether`, and webpack resolves the package through that field. So `import 'expose-loader?exposes=Tether!tether'` put the **module namespace object** on `window.Tether`: `new Tether(...)` threw `Tether is not a constructor` and Bootstrap 4 alpha's tooltips and popovers stayed broken - the password strength hint on the registration form is the reported symptom. expose-loader splits an entry on `|` into `globalName` and `moduleLocalName`, so `Tether|default` exposes the export itself.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes https://github.com/PrestaShop/PrestaShop/issues/39088
| Sponsor company |
| How to test?    | Open the registration form on the front office and type in the password field. Before this change the console shows `Uncaught TypeError: Tether is not a constructor` and the strength hint does not appear; after it, no error. Any module using a Bootstrap popover or tooltip in the classic theme is affected the same way, as reported on the thread.

### Measured, in the built bundle

Same webpack config, production mode, only `_dev/js/theme.js` differing:

```
before   void 0 === i.Tether && (i.Tether = r)                       // r is the imported namespace
after    var r = n(682), i = n(799), o = r.default;
         void 0 === i.Tether && (i.Tether = o)                       // o is the class
```

The chain that produces it, read in the installed packages rather than assumed:

```
_dev/node_modules/tether/package.json      module: dist/js/tether.esm.js
        tether.esm.js last line            export default Tether;
_dev/node_modules/expose-loader 5.0.0
        dist/utils.js:22-53                splits each entry on '|' into globalName / moduleLocalName
        dist/index.js:60-73                emits ___IMPORT___.<moduleLocalName> when one is given
```

`npx webpack --mode production` exits 0 and `npx eslint -c .eslintrc.js js/theme.js` exits 0. `assets/` is
gitignored in this repository, so the built output is not in the diff.

### Why not the approach in the closed PR

`classic-theme#178` (ChillCode, closed unmerged 2025-12-26) added
`new webpack.ProvidePlugin({Tether: 'tether'})`. ProvidePlugin injects a module-scoped variable into modules
that reference the identifier; it does not set `window.Tether`, which is what Bootstrap's dist build looks
for, and it would supply the same namespace object rather than the constructor. It is closed, so it blocks
nothing.

### Verification limit

The bundle assignment is measured; I have not opened the registration form in a browser. The reporter
measured the same thing from the other end - `Tether.default` is the constructor, `Tether` is not - and a
second reporter (`JBWModules`) hit it through Bootstrap popovers in their own modules.
