### PR TITLE
Restore the 2.2.0 delivery option changes that 3.x never received

### DIFF
--- a/_dev/css/components/checkout.scss
+++ b/_dev/css/components/checkout.scss
@@ -369,10 +369,6 @@ body#checkout {
     }
 
     .delivery-options {
-      > .row {
-        border-right: 0.1rem solid darken($gray-lighter, 20%);
-      }
-
       .delivery-option {
         min-height: 80px;
         padding: 0.9375rem 0;
@@ -406,6 +402,10 @@ body#checkout {
         img {
           width: 3.125rem;
         }
+      }
+
+      .carrier-extra-content {
+        padding-block-end: 1rem;
       }
     }
 

--- a/_dev/js/checkout.js
+++ b/_dev/js/checkout.js
@@ -75,7 +75,12 @@ $(document).ready(() => {
     }
     // Hide all carrier extra content ...
     $(prestashop.themeSelectors.checkout.carrierExtraContent).hide();
-    // and show the one related to the selected carrier
-    params.deliveryOption.next(prestashop.themeSelectors.checkout.carrierExtraContent).slideDown();
+
+    // Show the one related to the selected carrier
+    const carrierExtraContent = params.deliveryOption.next(prestashop.themeSelectors.checkout.carrierExtraContent);
+
+    if (carrierExtraContent.html().trim() !== '') {
+      carrierExtraContent.slideDown();
+    }
   });
 });

--- a/templates/checkout/_partials/steps/shipping.tpl
+++ b/templates/checkout/_partials/steps/shipping.tpl
@@ -41,7 +41,7 @@
           {block name='delivery_options'}
             <div class="delivery-options">
               {foreach from=$delivery_options item=carrier key=carrier_id}
-                  <div class="row delivery-option js-delivery-option">
+                  <div class="delivery-option js-delivery-option">
                     <div class="col-sm-1">
                       <span class="custom-radio float-xs-left">
                         <input type="radio" name="delivery_option[{$id_address}]" id="delivery_option_{$carrier.id}" value="{$carrier_id}"{if $delivery_option == $carrier_id} checked{/if}>
@@ -71,7 +71,7 @@
                       </div>
                     </label>
                   </div>
-                  <div class="row carrier-extra-content js-carrier-extra-content"{if $delivery_option != $carrier_id} style="display:none;"{/if}>
+                  <div class="carrier-extra-content js-carrier-extra-content"{if ($delivery_option != $carrier_id) || ($delivery_option == $carrier_id && empty($carrier.extraContent))} style="display:none;"{/if}>
                     {$carrier.extraContent nofilter}
                   </div>
                   <div class="clearfix"></div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | The 3.0.x line was branched before two commits that shipped in 2.2.0, and both are still absent from `develop`. `c24f8372` ("fix: alignment issue") drops the Bootstrap `row` class from `.delivery-option` and `.carrier-extra-content`, removes the now unused `.delivery-options > .row` border-right and gives `.carrier-extra-content` its own bottom padding. `acd52d3e` ("feat: improve display of extra block") keeps the extra content box hidden when the selected carrier has none, in the template **and** in `checkout.js`. Both cherry-pick cleanly onto `develop`.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes https://github.com/PrestaShop/PrestaShop/issues/39091
| Sponsor company |
| How to test?    | On the checkout shipping step, pick a carrier that has no extra content: before this change an empty `carrier-extra-content` box is slid open under it, after it nothing is shown. The delivery option rows also regain the alignment fix - the `row` class and the `.delivery-options > .row` border-right are gone together, which is how 2.2.x renders them.

### Measured, against the tags

The reporter suspected `shipping.tpl` had been rolled back. It is stronger than that - the file on **every**
3.0.x tag and on `develop` is **byte identical to 2.1.3**:

```
2.1.3   templates/checkout/_partials/steps/shipping.tpl   blob 837cfc2b
2.2.0                                                     blob 93409880
3.0.2                                                     blob 837cfc2b   <- back to the 2.1.3 blob
develop                                                   same two lines as 2.1.3
```

**And it is not only the template.** Both commits had halves outside `templates/`, and `develop` is missing
those too:

```
_dev/js/checkout.js:79            slideDown() still unguarded      (acd52d3e added the emptiness check)
_dev/css/.../checkout.scss:372    > .row { border-right: ... }     (c24f8372 removed it)
                                  .carrier-extra-content { ... }   absent    (c24f8372 added it)
```

So re-applying the template alone would have been wrong: the `row` removal only makes sense together with the
SCSS rule that was styling `> .row`, and the template's `display:none` condition is the pair of the JS guard.

### Answering the reporter's second question

They asked whether other 2.2.0 changes were lost as well. Checked every file changed between `2.1.3` and
`2.2.0` under `templates/`, comparing each against `develop`: **`shipping.tpl` is the only one whose current
content still equals the 2.1.3 version.** So this is the whole of it, and the two commits above are the whole
of that.

### Verification

Both commits cherry-pick with no conflict. After them: `shipping.tpl`'s two lines are identical to the 2.2.0
version, `checkout.js` carries the `carrierExtraContent.html().trim() !== ''` guard, the stale `> .row` rule
is gone and `.carrier-extra-content` has its padding. `node --check` passes on `checkout.js` and the SCSS
braces balance (205/205). `assets/` is not in the diff, as the theme requires.

### Verification limit

I have not rebuilt the theme assets or looked at the checkout in a browser. What is measured is that the two
commits are absent, that they apply cleanly, and that the result matches what 2.2.0 shipped.
