### PR TITLE
Drop the Product Details tab when it has nothing to show

### DIFF
--- a/templates/catalog/_partials/product-details.tpl
+++ b/templates/catalog/_partials/product-details.tpl
@@ -1,8 +1,7 @@
-<div class="js-product-details tab-pane fade{if !$product.description} in active{/if}"
-     id="product-details"
-     data-product="{$product.embedded_attributes|json_encode}"
-     role="tabpanel"
-  >
+{* Every block below is conditional, so the pane can come out with nothing in it. Capture it first and
+   emit the wrapper only when it holds something, so product.tpl can drop the tab instead of showing an
+   empty panel. Child themes overriding any block are unaffected - the blocks are unchanged. *}
+{capture name='product_details_content'}
   {block name='product_reference'}
     {if !empty($product_manufacturer.id)}
       <div class="product-manufacturer">
@@ -55,9 +54,14 @@
   {/block}
 
   {block name='product_out_of_stock'}
-    <div class="product-out-of-stock">
-      {hook h='actionProductOutOfStock' product=$product}
-    </div>
+    {* The six sibling blocks all guard their markup; this one emitted its wrapper even when no module
+       answered the hook, which is what left the pane holding a single empty div. *}
+    {capture name='product_out_of_stock'}{hook h='actionProductOutOfStock' product=$product}{/capture}
+    {if trim($smarty.capture.product_out_of_stock) !== ''}
+      <div class="product-out-of-stock">
+        {$smarty.capture.product_out_of_stock nofilter}
+      </div>
+    {/if}
   {/block}
 
   {block name='product_features'}
@@ -98,4 +102,22 @@
       </div>
     {/if}
   {/block}
-</div>
+{/capture}
+
+{* Keep the pane when it has content. When it has none it is only kept if there is no description tab,
+   because then this pane is the one carrying `active` and something has to be shown.
+
+   The answer is published as a variable rather than left for the caller to infer from this template's
+   output: in debug mode SmartyDevTemplate wraps every include in `<!-- begin ... -->` comments, so a
+   caller testing the rendered markup for emptiness would find it non-empty on every dev shop. *}
+{assign var='product_details_has_content' value=(trim($smarty.capture.product_details_content) !== '') scope='root'}
+
+{if $product_details_has_content || !$product.description}
+  <div class="js-product-details tab-pane fade{if !$product.description} in active{/if}"
+       id="product-details"
+       data-product="{$product.embedded_attributes|json_encode}"
+       role="tabpanel"
+    >
+    {$smarty.capture.product_details_content nofilter}
+  </div>
+{/if}

--- a/templates/catalog/product.tpl
+++ b/templates/catalog/product.tpl
@@ -139,6 +139,13 @@
             {/block}
 
             {block name='product_tabs'}
+              {* Rendered up front so the nav can tell whether the Product Details tab has anything to show.
+                 The partial decides that itself and returns nothing when it does not. *}
+              {capture name='product_details_pane'}
+                {block name='product_details'}
+                  {include file='catalog/_partials/product-details.tpl'}
+                {/block}
+              {/capture}
               <div class="tabs">
                 <ul class="nav nav-tabs" role="tablist">
                   {if $product.description}
@@ -152,15 +159,17 @@
                          {if $product.description} aria-selected="true"{/if}>{l s='Description' d='Shop.Theme.Catalog'}</a>
                     </li>
                   {/if}
-                  <li class="nav-item">
-                    <a
-                      class="nav-link{if !$product.description} active js-product-nav-active{/if}"
-                      data-toggle="tab"
-                      href="#product-details"
-                      role="tab"
-                      aria-controls="product-details"
-                      {if !$product.description} aria-selected="true"{/if}>{l s='Product Details' d='Shop.Theme.Catalog'}</a>
-                  </li>
+                  {if $product_details_has_content || !$product.description}
+                    <li class="nav-item">
+                      <a
+                        class="nav-link{if !$product.description} active js-product-nav-active{/if}"
+                        data-toggle="tab"
+                        href="#product-details"
+                        role="tab"
+                        aria-controls="product-details"
+                        {if !$product.description} aria-selected="true"{/if}>{l s='Product Details' d='Shop.Theme.Catalog'}</a>
+                    </li>
+                  {/if}
                   {if $product.attachments}
                     <li class="nav-item">
                       <a
@@ -190,9 +199,7 @@
                    {/block}
                  </div>
 
-                 {block name='product_details'}
-                   {include file='catalog/_partials/product-details.tpl'}
-                 {/block}
+                 {$smarty.capture.product_details_pane nofilter}
 
                  {block name='product_attachments'}
                    {if $product.attachments}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | Every block in `product-details.tpl` is wrapped in an `{if}` except `product_out_of_stock`, which emitted `<div class="product-out-of-stock">` even when no module answered `actionProductOutOfStock`. A product with no manufacturer, no reference, hidden quantities, no availability date, no features, no specific references and no condition therefore produced a Product Details pane whose entire content was that one empty div - and the tab itself is rendered unconditionally, unlike Description and Attachments which are both guarded. The out-of-stock block is now guarded the way its six siblings are, and the partial publishes whether it has any content so `product.tpl` can drop the nav item as well.
| Type?           | bug fix
| BC breaks?      | no
| Deprecations?   | no
| Fixed ticket?   | Fixes https://github.com/PrestaShop/PrestaShop/issues/39230
| Sponsor company |
| How to test?    | Create a product with stock management disabled and no reference, no brand, no features, no specific references and no condition, as the reporter describes. Before this change the product page shows a Product Details tab containing nothing but an empty `div`. After it, the tab is not rendered at all and Description stays selected. A product with any of those fields set is unchanged.

### Verified against PrestaShop's own Smarty

Both templates compile, and the partial was rendered in the running shop for the three cases that matter.
`flag` is `product_details_has_content`, the variable `product.tpl` now reads; the pane column has the
debug comments stripped:

```
empty + description present : flag=false  pane=NONE   -> tab dropped, which is the reported case
one block has content       : flag=true   pane=387b   -> tab kept, reference rendered
empty + NO description tab  : flag=false  pane=265b   -> pane kept, because it is the one carrying `active`
```

### Why the decision travels as a variable and not as "is the include empty"

The obvious shape is to `{capture}` the include in `product.tpl` and test the captured markup. That is wrong
here, and the render test is what caught it: in debug mode `SmartyDevTemplate::fetch()` wraps every include
in `<!-- begin ... -->` / `<!-- end ... -->`, so the capture is **never** empty on a dev shop. The guard would
have looked correct, passed a compile check, worked in production and silently done nothing for every
developer. The partial therefore decides for itself and publishes the answer with `scope='root'`.

### The third case, and why the tab is not always dropped

`product.tpl` gives `active` to Description when there is one and to Product Details otherwise. Dropping the
tab whenever it is empty would leave a product with no description and no details with no active pane at
all, and any Attachments or extra tab would render hidden. So an empty pane is still kept when there is no
description - it is the only thing that can carry `active`. The reported scenario has a description, so it
is fixed.

### Scope

Classic theme only. Hummingbird has no `product_out_of_stock` block in its `product-details.tpl`, so it does
not carry this defect. `assets/` is untouched, as the theme requires.
