### PR TITLE
Render the order product line hook on every order product line

### DIFF
--- a/templates/customer/_partials/order-detail-no-return.tpl
+++ b/templates/customer/_partials/order-detail-no-return.tpl
@@ -91,6 +91,7 @@
                 </div>
               {/foreach}
             {/if}
+            {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
           </td>
           <td>
             {$product.quantity}
@@ -137,6 +138,7 @@
                 </div>
               {/foreach}
             {/if}
+            {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
           </div>
           <div class="col-sm-7 qty">
             <div class="row">

--- a/templates/customer/_partials/order-detail-product-line-no-return-mobile.tpl
+++ b/templates/customer/_partials/order-detail-product-line-no-return-mobile.tpl
@@ -24,6 +24,7 @@
             </div>
           {/foreach}
         {/if}
+        {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
       </div>
       <div class="col-sm-7 qty">
         <div class="row">

--- a/templates/customer/_partials/order-detail-product-line-no-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-no-return.tpl
@@ -59,6 +59,7 @@
           </div>
         {/foreach}
       {/if}
+      {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
     </td>
     <td>
       {$product.quantity}

--- a/templates/customer/_partials/order-detail-product-line-return-mobile.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return-mobile.tpl
@@ -29,6 +29,7 @@
                 </div>
               {/foreach}
             {/if}
+            {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
           </div>
           <div class="col-sm-7 qty">
             <div class="row">

--- a/templates/customer/_partials/order-detail-product-line-return.tpl
+++ b/templates/customer/_partials/order-detail-product-line-return.tpl
@@ -62,6 +62,7 @@
           </div>
         {/foreach}
       {/if}
+      {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
     </td>
     <td class="qty">
       <div class="current">

--- a/templates/customer/_partials/order-detail-return.tpl
+++ b/templates/customer/_partials/order-detail-return.tpl
@@ -98,6 +98,7 @@
                   </div>
                 {/foreach}
               {/if}
+              {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
             </td>
             <td class="qty">
               <div class="current">
@@ -167,6 +168,7 @@
                       </div>
                     {/foreach}
                   {/if}
+                  {hook h='displayOrderDetailProductLine' id_order=$product.id_order id_order_detail=$product.id_order_detail id_product=$product.id_product}
                 </div>
                 <div class="col-sm-7 qty">
                   <div class="row">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Call the new `displayOrderDetailProductLine` hook on every product line of the order detail page, so a module can show information next to one product of an order.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below.
| Fixed issue or discussion?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/23245
| Related PRs       | PrestaShop/PrestaShop#TBD declares the hook. PrestaShop/hummingbird#TBD does the same for the other shipped theme.
| Sponsor company   | --

### Why

The order detail page has one hook, `displayOrderDetail`, and it is executed once for the whole page
with the order as its only parameter. Nothing receives a single product line, so a module cannot show
information next to one product.

### What it does

One `{hook h='displayOrderDetailProductLine' ...}` at the end of the product cell of every line, next
to the reference and the download link. It passes identifiers only - `$product.id_order`,
`$product.id_order_detail`, `$product.id_product` - all three of which the presented product row
already carries (`Order::getProductsDetail()` selects `od.*`), so the partials stay self contained.

**Eight call sites.** The theme renders every line twice, once in a `hidden-sm-down` table and once in
a `hidden-md-up` list, and the two single shipment templates hold those rows inline while the four
line partials serve the multishipment ones:

```
order-detail-no-return.tpl                        wide + narrow, inline
order-detail-return.tpl                           wide + narrow, inline
order-detail-product-line-no-return.tpl           wide,   multishipment
order-detail-product-line-return.tpl              wide,   multishipment
order-detail-product-line-no-return-mobile.tpl    narrow, multishipment
order-detail-product-line-return-mobile.tpl       narrow, multishipment
```

A module's output therefore appears twice in the document and once on screen, exactly like the product
name and the reference next to it. Adding the call to only one of the two renderings would have made
the hook disappear at a breakpoint.

**That makes idempotency part of the contract, and it differs between the two shipped themes:** a
listener fires twice per order line here and once on hummingbird. So a listener must not count, log a
row or emit a fixed `id` or `name` attribute - this theme already prefixes its own ids with
`_desktop_` and `_mobile_` for exactly this reason, and a module rendering into the hook has to
follow that. Worth stating in the devdocs entry alongside the parameters.

### How to test

Register a module on `displayOrderDetailProductLine` that returns some markup from
`hookDisplayOrderDetailProductLine($params)`, then open an order under Your account > Order history >
Details, at a wide and at a narrow viewport. The markup appears under the product name of every line
in both, and `$params` carries the three identifiers of that line.

### Measured on a running 9.2 shop

A probe module returning `<!--PROBE-FO id_order=... id_order_detail=... id_product=...-->` was
installed and registered on the hook, this theme's six templates were deployed with a per-site marker,
the shop was switched to `classic`, and the order detail page was fetched over HTTP as a logged in
customer owning a two product order. All eight sites fire, once per product each:

```
inline-nr-desktop 2   inline-nr-mobile 2   inline-r-desktop 2   inline-r-mobile 2
partial-nr-desktop 2  partial-nr-mobile 2  partial-r-desktop 2  partial-r-mobile 2
probe output: id_order=1 id_order_detail=1 id_product=1  and  id_order=1 id_order_detail=2 id_product=2
```

The two `inline-nr-*` sites are the ones the real selection reaches on that order
(`$order.details.is_returnable` false, no shipments); the other six were forced by temporarily
including them from `order-detail.tpl`, which proves each template compiles and emits the hook with
the right identifiers, but not that the selection reaches them.

Everything was put back afterwards: the seven deployed templates restored and checked by md5, the shop
switched back to `hummingbird`, the probe module uninstalled and deleted with its hook rows, the probe
customer and its related rows deleted, `ps_orders.id_customer` for the test order set back, and
`PS_ORDER_RETURN` set back to 0.

### Notes for publishing

- Held under the standing publish hold. Draft, weekend or after 20:00 CEST.
- SharakPL's open #143 also edits `order-detail-return.tpl`; its hunks are at lines 29 to 35 and 42 to
  48, and the two lines added here are at 101 and 170. No overlap.
- The desktop and narrow renderings of a line are near duplicates of each other and of the four line
  partials. Deduplicating them would reduce this hook to two call sites, but it is a structural change
  that does not belong in the same PR as a one line hook call.
